### PR TITLE
7 day cutoff for network stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Endpoints:
 Text: status of connection to db
 
 GET
-`/hosts/list`
+`/hosts/list-available?days=7`
+
+days = Cut off time. Records older than this will be ignored.
 
 #### `200 OK`
 
@@ -26,14 +28,16 @@ GET
     "holoportModel": "string",
     "hostingInfo": "string",
     "error": "string",
-    "alphaTest": true,
+    "alphaProgram": true,
     "assignedTo": "string"
   }
 ]
 ```
 
 GET
-`/hosts/registered`
+`/hosts/registered?days=7`
+
+days = Cut off time. Records older than this will be ignored.
 
 #### `200 OK`
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -98,7 +98,7 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSu
         .collection("holoports_status");
 
     let cutoff_ms = get_cutoff_timestamp(cutoff);
-
+    println!("{}", cutoff_ms.to_string());
     let pipeline = vec![
         doc! {
             // only successful ssh results in last 7 days

--- a/src/db.rs
+++ b/src/db.rs
@@ -98,7 +98,6 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSu
         .collection("holoports_status");
 
     let cutoff_ms = get_cutoff_timestamp(cutoff);
-    println!("{}", cutoff_ms.to_string());
     let pipeline = vec![
         doc! {
             // only successful ssh results in last 7 days

--- a/src/db.rs
+++ b/src/db.rs
@@ -7,7 +7,9 @@ use std::collections::HashMap;
 use std::env::var;
 use std::time::{SystemTime, Duration};
 
-use crate::types::{Assignment, Capacity, Host, HostSummary, Performance, Result, Uptime};
+use crate::types::{Assignment, Capacity, Host, HostSummary, Performance, Result, Uptime, ListAvailableError, BadRequest};
+
+const DAYS_TOO_LARGE: BadRequest = BadRequest("Days specified is too large. Cutoff is earlier than start of unix epoch");
 
 // AppDbPool is managed by Rocket as a State, which means it is available across threads.
 // Type mongodb::Database (starting v2.0.0 of mongodb driver) represents a connection pool to db,
@@ -78,17 +80,17 @@ pub async fn network_capacity(db: &Client) -> Result<Capacity> {
 
 // Return the most recent record for hosts stored in `holoports_status` collection that have a successful SSH record
 // Ignores records older than <cutoff> days
-pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSummary>> {
+pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSummary>, ListAvailableError> {
     // Retrieve and store in memory all holoport assignments
     let hp_assignment: Collection<Assignment> = db
         .database("host_statistics")
         .collection("alpha_program_holoports");
 
-    let mut cursor = hp_assignment.find(None, None).await?;
+    let mut cursor = hp_assignment.find(None, None).await.map_err(Debug).map_err(ListAvailableError::Database)?;
 
     let mut assignment_map = HashMap::new();
 
-    while let Some(a) = cursor.try_next().await? {
+    while let Some(a) = cursor.try_next().await.map_err(Debug).map_err(ListAvailableError::Database)? {
         assignment_map.insert(a.name, "");
     }
 
@@ -97,7 +99,10 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSu
         .database("host_statistics")
         .collection("holoports_status");
 
-    let cutoff_ms = get_cutoff_timestamp(cutoff);
+    let cutoff_ms = match get_cutoff_timestamp(cutoff) {
+        Some(x) => x,
+        None => return Err(ListAvailableError::BadRequest(DAYS_TOO_LARGE))
+    };
     let pipeline = vec![
         doc! {
             // only successful ssh results in last <cutoff> days
@@ -129,7 +134,7 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSu
 
     let options = AggregateOptions::builder().allow_disk_use(true).build();
      
-    let cursor = hp_status.aggregate(pipeline, Some(options)).await?;
+    let cursor = hp_status.aggregate(pipeline, Some(options)).await.map_err(Debug).map_err(ListAvailableError::Database)?;
 
     // Update fields alpha_test and assigned_to based on the content of assignment_map
     let cursor_extended = cursor.try_filter_map(|host| async {
@@ -142,33 +147,38 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSu
         Ok(Some(host))
     });
 
-    cursor_extended.try_collect().await.map_err(Debug)
+    cursor_extended.try_collect().await.map_err(Debug).map_err(ListAvailableError::Database)
 }
 
 // This gets a list of all HPs including those not SSH'd
-pub async fn list_registered_hosts(db: &Client, cutoff: u64) -> Result<Vec<bson::Bson>> {
+pub async fn list_registered_hosts(db: &Client, cutoff: u64) -> Result<Vec<bson::Bson>, ListAvailableError> {
     // Retrieve all holoport statuses and format for an API response
     let hp_status: Collection<Host> = db
         .database("host_statistics")
         .collection("holoports_status");
 
-    let ms = get_cutoff_timestamp(cutoff);
+    let cutoff_ms = match get_cutoff_timestamp(cutoff) {
+        Some(x) => x,
+        None => return Err(ListAvailableError::BadRequest(DAYS_TOO_LARGE))
+    };
 
-    let filter = doc!{"timestamp": {"$gte": ms.to_string()}};  
+    let filter = doc!{"timestamp": {"$gte": cutoff_ms}};  
 
-    hp_status.distinct("name", filter, None).await.map_err(Debug)
+    Ok(hp_status.distinct("name", filter, None).await.map_err(Debug).map_err(ListAvailableError::Database)?)
 }
 
 // Helper function to get cutoff timestamp for filter
 // We use u64 for days because otherwise we have to recast as u64 in the function, and 4 bytes isn't a big deal here
-fn get_cutoff_timestamp(days: u64) -> i64 {
+// Returns None if days is too large and causes negative timestamp (propagates .checked_sub() which does the same)
+fn get_cutoff_timestamp(days: u64) -> Option<i64> {
     let current_timestamp = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("SystemTime should be after unix epoch");
     let valid_duration = Duration::from_secs(60 * 60 * 24 * days);
+
     let cutoff_timestamp = current_timestamp
-        .checked_sub(valid_duration)
-        .expect("You can't go back further in time than the start of the Unix epoch!");
+    .checked_sub(valid_duration)?;
     use std::convert::TryInto;
-    cutoff_timestamp.as_millis().try_into().unwrap()
+    Some(cutoff_timestamp.as_millis().try_into().expect("We should be fewer than 2^63 milliseconds since start of unix epoch"))
 }
+

--- a/src/db.rs
+++ b/src/db.rs
@@ -104,7 +104,7 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSu
             // only successful ssh results in last 7 days
             "$match": {
                 "sshSuccess": true,
-                "timestamp": {"$gte": cutoff_ms.to_string()}
+                "timestamp": {"$gte": cutoff_ms}
             }
         },
         doc! {
@@ -161,7 +161,7 @@ pub async fn list_registered_hosts(db: &Client, cutoff: u64) -> Result<Vec<bson:
 }
 
 // Helper function to get cutoff timestamp for filter
-fn get_cutoff_timestamp(days: u64) -> u128 {
+fn get_cutoff_timestamp(days: u64) -> i64 {
     let duration = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("SystemTime should be after unix epoch");
@@ -169,8 +169,6 @@ fn get_cutoff_timestamp(days: u64) -> u128 {
     let one_week_ago = duration
         .checked_sub(one_week)
         .expect("SystemTime should be at least one week after unix epoch");
-    one_week_ago.as_millis()
+    use std::convert::TryInto;
+    one_week_ago.as_millis().try_into().unwrap()
 }
-
-    
-    

--- a/src/db.rs
+++ b/src/db.rs
@@ -77,7 +77,7 @@ pub async fn network_capacity(db: &Client) -> Result<Capacity> {
 }
 
 // Return the most recent record for hosts stored in `holoports_status` collection that have a successful SSH record
-// Ignores records older than 7 days
+// Ignores records older than <cutoff> days
 pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSummary>> {
     // Retrieve and store in memory all holoport assignments
     let hp_assignment: Collection<Assignment> = db

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use rocket::{self, get, State};
 
 mod db;
 mod types;
-use types::{Capacity, HostSummary, Result, Uptime};
+use types::{Capacity, HostSummary, Result, Uptime, ListAvailableError};
 
 #[get("/")]
 async fn index(pool: &State<db::AppDbPool>) -> Result<String> {
@@ -20,12 +20,12 @@ async fn uptime(name: String, pool: &State<db::AppDbPool>) -> Result<Option<Json
 }
 
 #[get("/list-available?<days>")]
-async fn list_available(days: u64, pool: &State<db::AppDbPool>) -> Result<Json<Vec<HostSummary>>> {
+async fn list_available(days: u64, pool: &State<db::AppDbPool>) -> Result<Json<Vec<HostSummary>>, ListAvailableError> {
     Ok(Json(db::list_available_hosts(&pool.mongo, days).await?))
 }
 
 #[get("/registered?<days>")]
-async fn list_registered(days: u64, pool: &State<db::AppDbPool>) -> Result<Json<Vec<bson::Bson>>> {
+async fn list_registered(days: u64, pool: &State<db::AppDbPool>) -> Result<Json<Vec<bson::Bson>>, ListAvailableError> {
     Ok(Json(db::list_registered_hosts(&pool.mongo, days).await?))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,14 +19,14 @@ async fn uptime(name: String, pool: &State<db::AppDbPool>) -> Result<Option<Json
     Ok(None)
 }
 
-#[get("/list")]
-async fn list_all(pool: &State<db::AppDbPool>) -> Result<Json<Vec<HostSummary>>> {
-    Ok(Json(db::list_all_hosts(&pool.mongo).await?))
+#[get("/list-available?<days>")]
+async fn list_available(days: u64, pool: &State<db::AppDbPool>) -> Result<Json<Vec<HostSummary>>> {
+    Ok(Json(db::list_available_hosts(&pool.mongo, days).await?))
 }
 
-#[get("/registered")]
-async fn list_registered(pool: &State<db::AppDbPool>) -> Result<Json<Vec<bson::Bson>>> {
-    Ok(Json(db::list_registered_hosts(&pool.mongo).await?))
+#[get("/registered?<days>")]
+async fn list_registered(days: u64, pool: &State<db::AppDbPool>) -> Result<Json<Vec<bson::Bson>>> {
+    Ok(Json(db::list_registered_hosts(&pool.mongo, days).await?))
 }
 
 #[get("/capacity")]
@@ -41,7 +41,7 @@ async fn main() -> Result<(), rocket::Error> {
         .mount("/", rocket::routes![index])
         .mount(
             "/hosts/",
-            rocket::routes![uptime, list_all, list_registered],
+            rocket::routes![uptime, list_available, list_registered],
         )
         .mount("/network/", rocket::routes![capacity])
         .launch()

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use rocket::serde::{Deserialize, Serialize};
+use rocket::{serde::{Deserialize, Serialize}, response::Responder};
 
 use bson::oid::ObjectId;
 use mongodb::{bson, error::Error};
@@ -96,4 +96,14 @@ pub struct HostSummary {
 #[serde(rename_all = "camelCase")]
 pub struct Assignment {
     pub name: String,
+}
+
+#[derive(Responder)]
+#[response(status = 400)]
+pub struct BadRequest(pub &'static str);
+
+#[derive(Responder)]
+pub enum ListAvailableError {
+    BadRequest(BadRequest),
+    Database(Debug<Error>)
 }


### PR DESCRIPTION
- Added a cutoff in days for `list` and `register` endpoints so we don't return really old and stale entries that create noise
- Renamed `list` to `list_available` and related function renaming, since we're not returning ALL but rather just HPs that we can SSH into i.e. are available