### PR TITLE
Net stats api

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "holoport",
+        "hpos"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "cSpell.words": [
-        "holoport",
-        "hpos"
-    ]
-}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1009,7 @@ version = "0.1.0"
 dependencies = [
  "base36 0.0.1",
  "base64",
+ "bincode",
  "chrono",
  "ed25519-dalek",
  "hpos-config-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time 0.1.44",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -449,9 +449,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "ed25519"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
+checksum = "eed12bbf7b5312f8da1c2722bc06d8c6b12c2d86a7fb35a194c7f3e6fc2bbe39"
 dependencies = [
  "serde",
  "signature",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
+checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -697,7 +697,7 @@ checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -739,12 +739,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -785,7 +782,7 @@ dependencies = [
 [[package]]
 name = "hpos-config-core"
 version = "0.1.1"
-source = "git+https://github.com/Holo-Host/hpos-config?branch=develop#572644c9669b3c980818eb72516a95d8eaf5ed37"
+source = "git+https://github.com/Holo-Host/hpos-config?rev=62e328974ad738551920c85ced6ddf92f2ece29c#62e328974ad738551920c85ced6ddf92f2ece29c"
 dependencies = [
  "argon2min",
  "arrayref",
@@ -1006,7 +1003,6 @@ dependencies = [
  "rocket",
  "serde",
  "serde_json",
- "tokio",
 ]
 
 [[package]]
@@ -2140,12 +2136,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -2448,12 +2443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,9 +2506,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,15 +186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,8 +1000,6 @@ version = "0.1.0"
 dependencies = [
  "base36 0.0.1",
  "base64",
- "bincode",
- "chrono",
  "ed25519-dalek",
  "hpos-config-core",
  "mongodb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,27 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.5",
  "once_cell",
  "version_check",
 ]
@@ -21,6 +36,35 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "argon2min"
+version = "0.3.0"
+source = "git+https://github.com/Holo-Host/argon2min?branch=2019-10-13-holo-config#28e765e4369e19bc0126bb46acaacadf1303de22"
+dependencies = [
+ "blake2-rfc",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-stream"
@@ -45,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -56,11 +100,11 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -76,15 +120,58 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
+name = "base36"
+version = "0.0.0"
+source = "git+https://github.com/transumption-unstable/base36?branch=2019-12-18-nix#4e6981e13ec5f3748dfe9b8870aa4e8ed749096d"
+dependencies = [
+ "base-x",
+ "failure",
+]
+
+[[package]]
+name = "base36"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c26bddc1271f7112e5ec797e8eeba6de2de211c1488e506b9500196dbf77c5"
+dependencies = [
+ "base-x",
+ "failure",
+]
 
 [[package]]
 name = "base64"
@@ -105,6 +192,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+dependencies = [
+ "arrayvec 0.4.12",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "bson"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff58d466782b57e0001c8e97c6a70c01c2359d7e13e257a83654c0b783ecc139"
+checksum = "41539b5c502b7c4e7b8af8ef07e5c442fe79ceba62a2aad8e62bd589b9454745"
 dependencies = [
  "ahash",
  "base64",
@@ -125,7 +233,7 @@ dependencies = [
  "hex",
  "indexmap",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -134,9 +242,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -146,9 +260,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -165,15 +279,30 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time 0.1.43",
+ "time 0.1.44",
  "winapi",
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.8"
+name = "cloudabi"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "const_fn"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
@@ -206,10 +335,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.13.0"
+name = "curve25519-dalek"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -217,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
 dependencies = [
  "fnv",
  "ident_case",
@@ -231,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
  "darling_core",
  "quote",
@@ -306,6 +448,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "ed25519"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
+dependencies = [
+ "serde",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,9 +480,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.29"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
 ]
@@ -330,6 +497,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -363,10 +561,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.17"
+name = "fuchsia-cprng"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -379,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -389,15 +593,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -406,18 +610,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -425,23 +627,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -451,8 +652,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -471,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -481,14 +680,31 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glob"
@@ -498,9 +714,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.7"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -567,10 +783,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hpos-config-core"
+version = "0.1.1"
+source = "git+https://github.com/Holo-Host/hpos-config?branch=develop#572644c9669b3c980818eb72516a95d8eaf5ed37"
+dependencies = [
+ "argon2min",
+ "arrayref",
+ "base36 0.0.0",
+ "base64",
+ "blake2b_simd",
+ "ed25519-dalek",
+ "failure",
+ "lazy_static",
+ "rand 0.6.5",
+ "serde",
+ "url",
+]
+
+[[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
@@ -590,21 +824,21 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.14"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -617,7 +851,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.2",
+ "socket2 0.4.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -643,20 +877,20 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "hashbrown",
  "serde",
 ]
 
 [[package]]
 name = "inlinable_string"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3094308123a0e9fd59659ce45e22de9f53fc1d2ac6e1feb9fef988e4f76cad77"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "instant"
@@ -687,15 +921,15 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -708,9 +942,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "linked-hash-map"
@@ -720,9 +954,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -738,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "loom"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b9df80a3804094bf49bb29881d18f6f05048db72127e84e09c26fc7c2324f5"
+checksum = "edc5c7d328e32cc4954e8e01193d7f0ef5ab257b5090b70a964e099a36034309"
 dependencies = [
  "cfg-if",
  "generator",
@@ -764,8 +998,16 @@ dependencies = [
 name = "match-service-api"
 version = "0.1.0"
 dependencies = [
+ "base36 0.0.1",
+ "base64",
+ "chrono",
+ "ed25519-dalek",
+ "hpos-config-core",
  "mongodb",
  "rocket",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -776,9 +1018,9 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -813,10 +1055,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mio"
-version = "0.7.14"
+name = "miniz_oxide"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -836,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d419667771704b002e6837d52f7461f70cea853f58c077d299f132ed6f75b2ad"
+checksum = "bacb6f8cee6bf010d7bc57550d859f6a4ffe255eb8c9a7014637fe988eaece64"
 dependencies = [
  "async-trait",
  "base64",
@@ -857,14 +1109,15 @@ dependencies = [
  "os_info",
  "pbkdf2",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_bytes",
  "serde_with",
  "sha-1",
  "sha2",
- "socket2 0.4.2",
+ "socket2 0.4.4",
  "stringprep",
  "strsim",
  "take_mut",
@@ -883,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "multer"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "408327e2999b839cd1af003fc01b2019a6c10a1361769542203f6fedc5179680"
+checksum = "5f8f35e687561d5c1667590911e6698a8cb714a134a7505718a182e7bc9d3836"
 dependencies = [
  "bytes",
  "encoding_rs",
@@ -893,19 +1146,25 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "memchr",
  "mime",
  "spin 0.9.2",
  "tokio",
  "tokio-util",
- "twoway",
  "version_check",
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.3.6"
+name = "nodrop"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -916,7 +1175,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -926,24 +1185,33 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.8.0"
+name = "object"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
@@ -953,9 +1221,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "os_info"
-version = "3.0.7"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac91020bfed8cc3f8aa450d4c3b5fa1d3373fc091c8a92009f3b27749d5a227"
+checksum = "023df84d545ef479cf67fd2f4459a613585c9db4852c2fad12ab70587859d340"
 dependencies = [
  "log",
  "winapi",
@@ -1026,9 +1294,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -1038,9 +1306,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-hack"
@@ -1049,16 +1317,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -1084,23 +1346,74 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1110,7 +1423,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1119,16 +1456,87 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.5",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 dependencies = [
- "rand_core",
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1240,7 +1648,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -1302,6 +1710,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,16 +1738,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.5"
+name = "rustls-pemfile"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "scoped-tls"
@@ -1374,9 +1797,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -1392,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1403,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1415,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
+checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
 dependencies = [
  "rustversion",
  "serde",
@@ -1451,15 +1874,24 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -1487,6 +1919,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,9 +1932,9 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
@@ -1511,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -1631,12 +2069,24 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1648,13 +2098,13 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1682,20 +2132,21 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1739,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1754,11 +2205,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -1767,15 +2217,16 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2 0.4.4",
  "tokio-macros",
  "winapi",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1795,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1806,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1835,9 +2286,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1847,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1858,11 +2309,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -1877,42 +2329,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
- "chrono",
  "lazy_static",
  "matchers",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0d7f5db438199a6e2609debe3f69f808d074e0a2888ee0bccb45fe234d03f4"
+checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1925,7 +2363,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "thiserror",
  "tinyvec",
@@ -1935,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad17b608a64bd0735e67bde16b0636f8aa8591f831a25d18443ed00a699770"
+checksum = "ecae383baad9995efaa34ce8e57d12c3f305e545887472a492b838f4b5cfb77a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1960,16 +2398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "twoway"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57ffb460d7c24cd6eda43694110189030a3d1dfe418416d9468fd1c1d290b47"
-dependencies = [
- "memchr",
- "unchecked-index",
-]
-
-[[package]]
 name = "typed-builder"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ubyte"
@@ -2006,12 +2434,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unchecked-index"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-xid"
@@ -2062,14 +2484,21 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.5",
+ "serde",
 ]
 
 [[package]]
-name = "version_check"
-version = "0.9.3"
+name = "valuable"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -2083,15 +2512,21 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2099,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2114,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2124,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2137,15 +2572,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2212,3 +2647,24 @@ name = "yansi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "match-service-api"
 version = "0.1.0"
-authors = ["peeech <pj@imagine-nyc.com>"]
+authors = [
+    "peeech <pj@imagine-nyc.com>",
+    "jetttech <lisa.jetton@holo.host>"
+]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,11 +14,10 @@ mongodb = "2.0.0"
 rocket = { version = "0.5.0-rc.1", features = ["json"] }
 base64 = "0.13.0"
 base36 = "=0.0.1"
-ed25519-dalek = "1.0.1"
+ed25519-dalek = { version = "1.0.0-pre.1" }
 serde_json = "1.0.79"
 serde = "1.0.136"
-tokio = ""
 
 [dependencies.hpos-config-core]
 git = "https://github.com/Holo-Host/hpos-config"
-branch = "develop"
+rev = "62e328974ad738551920c85ced6ddf92f2ece29c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4.19"
 serde_json = "1.0.79"
 serde = "1.0.136"
 tokio = ""
+bincode = "1.0"
 
 [dependencies.hpos-config-core]
 git = "https://github.com/Holo-Host/hpos-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,14 @@ edition = "2018"
 [dependencies]
 mongodb = "2.0.0"
 rocket = { version = "0.5.0-rc.1", features = ["json"] }
+base64 = "0.13.0"
+base36 = "=0.0.1"
+ed25519-dalek = "1.0.1"
+chrono = "0.4.19"
+serde_json = "1.0.79"
+serde = "1.0.136"
+tokio = ""
+
+[dependencies.hpos-config-core]
+git = "https://github.com/Holo-Host/hpos-config"
+branch = "develop"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,9 @@ rocket = { version = "0.5.0-rc.1", features = ["json"] }
 base64 = "0.13.0"
 base36 = "=0.0.1"
 ed25519-dalek = "1.0.1"
-chrono = "0.4.19"
 serde_json = "1.0.79"
 serde = "1.0.136"
 tokio = ""
-bincode = "1.0"
 
 [dependencies.hpos-config-core]
 git = "https://github.com/Holo-Host/hpos-config"

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,6 +6,7 @@ use rocket::response::Debug;
 use rocket::State;
 use std::env::var;
 use std::time::{Duration, SystemTime};
+use std::convert::TryFrom;
 
 use ed25519_dalek::PublicKey;
 use hpos_config_core::public_key::to_holochain_encoded_agent_key;
@@ -270,7 +271,10 @@ pub async fn add_host_stats(stats: HostStats, pool: &State<AppDbPool>) -> Result
         zt_ip: stats.zt_ip,
         wan_ip: stats.wan_ip,
         holoport_id: stats.holoport_id,
-        timestamp: Some(format!("{:?}", SystemTime::now())),
+        timestamp: SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .ok()
+            .map(|t| i64::try_from(t.as_secs()).ok().unwrap_or(0)),
     };
     add_holoport_status(holoport_status, &pool.mongo).await?;
     Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -238,12 +238,10 @@ pub async fn add_holoport_status(hps: HoloportStatus, db: &Client) -> Result<(),
 // Find registration values for host identified by email in the `opsconsoledb` collection `registration`
 // and determine whether the provided host pub key exists within record
 pub async fn verify_host(email: String, pub_key: String, db: &Client) -> Result<(), ApiError> {
-    println!("Verify host");
     let records: Collection<HostRegistration> = db
         .database("opsconsoledb")
         .collection("performance_summary");
 
-    println!("Verifing host");
     let host_registration = match records
         .find_one(Some(doc! {"email": email.clone()}), None)
         .await
@@ -252,16 +250,14 @@ pub async fn verify_host(email: String, pub_key: String, db: &Client) -> Result<
         Err(e) => return Err(ApiError::Database(Debug(e))),
     };
 
-    println!("found some: {:?}", host_registration);
     if host_registration
         .registration_code
         .iter()
-        .any(|r| r.agent_pub_keys.iter().any(|key| key.pub_key == pub_key))
+        .any(|r| r.agent_pub_keys.iter().any(|keys| keys.pub_key == pub_key))
     {
         return Ok(());
     }
 
-    // Decide on status code to return with error
     Err(ApiError::MissingRecord(ErrorMessageInfo(format!(
         "No host found with provided email. {:?}",
         email

--- a/src/db.rs
+++ b/src/db.rs
@@ -154,7 +154,7 @@ pub async fn list_registered_hosts(db: &Client, cutoff: u64) -> Result<Vec<bson:
         None => return Err(ApiError::BadRequest(DAYS_TOO_LARGE)),
     };
 
-    let filter = doc!{"timestamp": {"$gte": cutoff_ms}};
+    let filter = doc! {"timestamp": {"$gte": cutoff_ms}};
 
     Ok(hp_status
         .distinct("name", filter, None)
@@ -193,7 +193,7 @@ pub async fn add_holoport_status(hs: HostStats, db: &Client) -> Result<(), ApiEr
         "ssh_status": hs.ssh_status,
         "zt_ip": hs.zt_ip,
         "wan_ip": hs.wan_ip,
-        "holoport_id_base36": hs.holoport_id_base36,
+        "holoport_id": hs.holoport_id,
         "timestamp": hs.timestamp
     };
     match hp_status.insert_one(val.clone(), None).await {
@@ -249,7 +249,7 @@ pub fn decode_pubkey(holoport_id: &str) -> PublicKey {
 }
 
 pub async fn add_host_stats(stats: HostStats, pool: &State<AppDbPool>) -> Result<(), ApiError> {
-    let ed25519_pubkey = decode_pubkey(&stats.holoport_id_base36);
+    let ed25519_pubkey = decode_pubkey(&stats.holoport_id);
 
     // Confirm host exists in registration records
     let _ = verify_host(to_holochain_encoded_agent_key(&ed25519_pubkey), &pool.mongo)
@@ -269,7 +269,7 @@ pub async fn add_host_stats(stats: HostStats, pool: &State<AppDbPool>) -> Result
         ssh_status: stats.ssh_status,
         zt_ip: stats.zt_ip,
         wan_ip: stats.wan_ip,
-        holoport_id_base36: stats.holoport_id_base36,
+        holoport_id: stats.holoport_id,
         timestamp: Some(format!("{:?}", SystemTime::now())),
     };
     add_holoport_status(holoport_status, &pool.mongo).await?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -95,8 +95,6 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSt
       None => return Err(ApiError::BadRequest(DAYS_TOO_LARGE)),
     };
 
-    println!("{}", cutoff_ms);
-
     let hp_status: Collection<HostStats> =
         db.database("host_statistics").collection("holoport_status");
 
@@ -123,7 +121,7 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSt
                 "sshStatus": {"$first": "$sshStatus"},
                 "ztIp": {"$first": "$ztIp"},
                 "wanIp": {"$first": "$wanIp"},
-                "holoportIdBase36": {"$first": "$holoportIdBase36"},
+                "holoportId": {"$first": "$holoportId"},
                 "timestamp": {"$first": "$timestamp"},
             }
         },

--- a/src/db.rs
+++ b/src/db.rs
@@ -8,8 +8,8 @@ use std::env::var;
 use std::time::{Duration, SystemTime};
 
 use crate::types::{
-    ApiError, Assignment, Capacity, ErrorMessage, ErrorMessageInfo, HoloportStatus, Host,
-    HostRegistration, HostSummary, Performance, Result, Uptime,
+    ApiError, Assignment, Capacity, ErrorMessage, ErrorMessageInfo, Host, HostRegistration,
+    HostStats, HostSummary, Performance, Result, Uptime,
 };
 
 const DAYS_TOO_LARGE: ErrorMessage =
@@ -213,20 +213,20 @@ fn get_cutoff_timestamp(days: u64) -> Option<i64> {
 }
 
 // Add values to the collection `holoports_status`
-pub async fn add_holoport_status(hps: HoloportStatus, db: &Client) -> Result<(), ApiError> {
+pub async fn add_holoport_status(hs: HostStats, db: &Client) -> Result<(), ApiError> {
     let hp_status: Collection<Document> = db
         .database("host_statistics")
         .collection("holoports_status");
     let val = doc! {
-        "holoport_id": hps.holoport_id,
-        "ip": hps.ip,
-        "timestamp": hps.timestamp,
-        "ssh_success": hps.ssh_success,
-        "holo_network": hps.holo_network,
-        "channel": hps.channel,
-        "holoport_model": hps.holoport_model,
-        "hosting_info": hps.hosting_info,
-        "error": hps.error
+        "holo_network": hs.holo_network,
+        "channel": hs.channel,
+        "holoport_model": hs.holoport_model,
+        "ssh_status": hs.ssh_status,
+        "zt_ip": hs.zt_ip,
+        "wan_ip": hs.wan_ip,
+        "holoport_id_base36": hs.holoport_id_base36,
+        "timestamp": hs.timestamp,
+        "email": hs.email
     };
     match hp_status.insert_one(val.clone(), None).await {
         Ok(_) => Ok(()),

--- a/src/db.rs
+++ b/src/db.rs
@@ -187,13 +187,13 @@ pub async fn add_holoport_status(hs: HostStats, db: &Client) -> Result<(), ApiEr
     let hp_status: Collection<Document> =
         db.database("host_statistics").collection("holoport_status");
     let val = doc! {
-        "holo_network": hs.holo_network,
+        "holoNetwork": hs.holo_network,
         "channel": hs.channel,
-        "holoport_model": hs.holoport_model,
-        "ssh_status": hs.ssh_status,
-        "zt_ip": hs.zt_ip,
-        "wan_ip": hs.wan_ip,
-        "holoport_id": hs.holoport_id,
+        "holoportModel": hs.holoport_model,
+        "sshStatus": hs.ssh_status,
+        "ztIp": hs.zt_ip,
+        "wanIp": hs.wan_ip,
+        "holoportId": hs.holoport_id,
         "timestamp": hs.timestamp
     };
     match hp_status.insert_one(val.clone(), None).await {

--- a/src/db.rs
+++ b/src/db.rs
@@ -184,7 +184,7 @@ pub async fn list_registered_hosts(db: &Client, cutoff: u64) -> Result<Vec<bson:
         None => return Err(ApiError::BadRequest(DAYS_TOO_LARGE)),
     };
 
-    let filter = doc! {"timestamp": {"$gte": cutoff_ms}};
+    let filter = doc!{"timestamp": {"$gte": cutoff_ms}};
 
     Ok(hp_status
         .distinct("name", filter, None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,22 @@
+use base64;
+use ed25519_dalek::{PublicKey, Signature};
+use hpos_config_core::public_key::to_holochain_encoded_agent_key;
 use mongodb::bson;
+use rocket::data::{self, Data, FromData};
+use rocket::http::{Method, Status};
+use rocket::outcome::Outcome::*;
+use rocket::request::Request;
 use rocket::serde::json::Json;
-use rocket::{self, get, State};
+use rocket::{self, get, post, State};
+use std::time::SystemTime;
+// use rocket::figment::value::Value;
 
 mod db;
 mod types;
-use types::{Capacity, HostSummary, Result, Uptime, ListAvailableError};
+use types::{
+    ApiError, Capacity, HoloportStatus, HostError, HostSignature, HostStats, HostSummary, Result,
+    Uptime,
+};
 
 #[get("/")]
 async fn index(pool: &State<db::AppDbPool>) -> Result<String> {
@@ -20,18 +32,59 @@ async fn uptime(name: String, pool: &State<db::AppDbPool>) -> Result<Option<Json
 }
 
 #[get("/list-available?<days>")]
-async fn list_available(days: u64, pool: &State<db::AppDbPool>) -> Result<Json<Vec<HostSummary>>, ListAvailableError> {
+async fn list_available(
+    days: u64,
+    pool: &State<db::AppDbPool>,
+) -> Result<Json<Vec<HostSummary>>, ApiError> {
     Ok(Json(db::list_available_hosts(&pool.mongo, days).await?))
 }
 
 #[get("/registered?<days>")]
-async fn list_registered(days: u64, pool: &State<db::AppDbPool>) -> Result<Json<Vec<bson::Bson>>, ListAvailableError> {
+async fn list_registered(
+    days: u64,
+    pool: &State<db::AppDbPool>,
+) -> Result<Json<Vec<bson::Bson>>, ApiError> {
     Ok(Json(db::list_registered_hosts(&pool.mongo, days).await?))
 }
 
 #[get("/capacity")]
 async fn capacity(pool: &State<db::AppDbPool>) -> Result<Json<Capacity>> {
     Ok(Json(db::network_capacity(&pool.mongo).await?))
+}
+
+#[post("/stats", data = "<stats>")]
+async fn update_stats(stats: HostStats, pool: &State<db::AppDbPool>) -> Result<(), ApiError> {
+    // TODO: Return ApiError instead of unwraps:
+    let decoded_pubkey = base36::decode(&stats.holoport_id).unwrap();
+    let public_key = PublicKey::from_bytes(&decoded_pubkey).unwrap();
+
+    // Confirm host exists in registration records
+    db::verify_host(
+        stats.email,
+        to_holochain_encoded_agent_key(&public_key),
+        &pool.mongo,
+    )
+    .await
+    .or_else(|_| {
+        // todo: update error
+        return Err("Failure((Status::Unauthorized, HostError::MissingRecord))");
+    });
+
+    // Add utc timestamp to stats payload and insert into db
+    let timestamp = SystemTime::now();
+    let holoport_status = HoloportStatus {
+        timestamp,
+        holo_network: stats.holo_network,
+        channel: stats.channel,
+        holoport_model: stats.holoport_model,
+        ssh_success: stats.ssh_status,
+        ip: stats.wan_ip,
+        holoport_id: stats.holoport_id,
+        hosting_info: None,
+        error: None,
+    };
+    db::add_holoport_status(holoport_status, &pool.mongo).await?;
+    Ok(())
 }
 
 #[rocket::main]
@@ -46,4 +99,56 @@ async fn main() -> Result<(), rocket::Error> {
         .mount("/network/", rocket::routes![capacity])
         .launch()
         .await
+}
+
+#[rocket::async_trait]
+impl<'r> FromData<'r> for HostStats {
+    type Error = HostError;
+
+    async fn from_data(request: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
+        // todo: Handle Errors where `unwrap` is used
+        // Use data guard on `/stats` POST to verify host's signature in headers
+        if request.method() == Method::Post && request.uri().path() == "/stats" {
+            // TODO-QUESTION: Ask what the header name in which signature will be passed (using generic 'x-custom-header' for now)
+            let signature = request.headers().get_one("X-Custom-Header");
+            match signature {
+                Some(signature) => HostSignature(signature.to_string()),
+                None => return Failure((Status::Unauthorized, HostError::MissingSignature)),
+            };
+
+            // todo: Move this into a try_from Data into HostStats:
+            let body = data
+                .open(data::ByteUnit::max_value())
+                .stream_to(tokio::io::stdout())
+                .await
+                .unwrap();
+            let host_stats: HostStats = match serde_json::from_str(&format!("{}", body)) {
+                Ok(a) => a,
+                Err(_) => return Failure((Status::UnprocessableEntity, HostError::InvalidPayload)),
+            };
+
+            // TODO-QUESTION:Ask what encoding is being used (assuming BASE64 right now)
+            let decoded_sig = base64::decode(signature.unwrap()).unwrap();
+            let ed25519_sig = Signature::from_bytes(&decoded_sig).unwrap();
+            let decoded_data = data
+                .open(data::ByteUnit::max_value())
+                .into_bytes()
+                .await
+                .unwrap();
+
+            let decoded_pubkey = base36::decode(&host_stats.holoport_id).unwrap();
+            let public_key = PublicKey::from_bytes(&decoded_pubkey).unwrap();
+            public_key
+                .verify_strict(&decoded_data.value, &ed25519_sig)
+                .or_else(|_| {
+                    // todo: fix error reference
+                    return Err("Failure((Status::Unauthorized, HostError::InvalidSignature))");
+                });
+
+            return Success(host_stats);
+        }
+
+        // Otherwise no data guard check needed
+        Forward(data)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ impl<'r> FromData<'r> for HostStats {
             };
             let ed25519_sig = Signature::from_bytes(&decoded_sig).unwrap();
 
-            let ed25519_pubkey = db::decode_pubkey(&host_stats.holoport_id_base36);
+            let ed25519_pubkey = db::decode_pubkey(&host_stats.holoport_id);
 
             // TEMP NOTE: comment out for manual postman test - sig not verifiable
             return match ed25519_pubkey.verify_strict(&decoded_data.value, &ed25519_sig) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,10 @@
-use base64;
-use ed25519_dalek::Signature;
 use mongodb::bson;
-use rocket::data::{self, Data, FromData};
-use rocket::http::{Method, Status};
-use rocket::outcome::Outcome::*;
-use rocket::request::Request;
 use rocket::serde::json::Json;
 use rocket::{self, get, post, State};
 
 mod db;
 mod types;
-use types::{ApiError, Capacity, Error400, Error401, HostStats, Result, Uptime};
+use types::{ApiError, Capacity, HostStats, Result, Uptime};
 
 #[get("/")]
 async fn index(pool: &State<db::AppDbPool>) -> Result<String> {
@@ -63,76 +57,4 @@ async fn main() -> Result<(), rocket::Error> {
         .mount("/network/", rocket::routes![capacity])
         .launch()
         .await
-}
-
-#[rocket::async_trait]
-impl<'r> FromData<'r> for HostStats {
-    type Error = ApiError;
-
-    async fn from_data(request: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
-        // Use data guard on `/stats` POST to verify host's signature in headers
-        if request.method() == Method::Post && request.uri().path() == "/hosts/stats" {
-            let signature = match request.headers().get_one("x-hpos-signature") {
-                Some(signature) => signature.to_string(),
-                None => {
-                    return Failure((
-                        Status::Unauthorized,
-                        ApiError::MissingSignature(Error401::Message(
-                            "Host's hpos signature was not located in the request headers.",
-                        )),
-                    ))
-                }
-            };
-
-            let byte_unit_data = data.open(data::ByteUnit::max_value());
-            let decoded_data = byte_unit_data.into_bytes().await.unwrap();
-            let host_stats: HostStats = match serde_json::from_slice(&decoded_data.value) {
-                Ok(hs) => hs,
-                Err(e) => {
-                    return Failure((
-                        Status::UnprocessableEntity,
-                        ApiError::InvalidPayload(Error400::Info(
-                            format!("Provided payload to `hosts/stats` does not match expected payload. Error: {:?}", e),
-                        )),
-                    ));
-                }
-            };
-
-            // TEMP NOTE: comment out for manual postman test - sig not verifiable
-            let decoded_sig = match base64::decode(signature) {
-                Ok(ds) => ds,
-                Err(e) => {
-                    return Failure((
-                        Status::UnprocessableEntity,
-                        ApiError::InvalidSignature(Error401::Info(
-                            format!("Provided signature to `hosts/stats` does not have the expected encoding. Error: {:?}", e),
-                        )),
-                    ));
-                }
-            };
-            let ed25519_sig = Signature::from_bytes(&decoded_sig).unwrap();
-
-            let ed25519_pubkey = db::decode_pubkey(&host_stats.holoport_id);
-
-            // TEMP NOTE: comment out for manual postman test - sig not verifiable
-            return match ed25519_pubkey.verify_strict(&decoded_data.value, &ed25519_sig) {
-                Ok(_) => Success(host_stats),
-                Err(_) => Failure((
-                    Status::Unauthorized,
-                    ApiError::InvalidSignature(Error401::Message(
-                        "Provided host signature does not match signature of signed payload.",
-                    )),
-                )),
-            };
-
-            // TEMP NOTE: comment in for manual postman test - sig not verifiable
-            // return Success(host_stats);
-        }
-        Failure((
-            Status::BadRequest,
-            ApiError::BadRequest(Error400::Message(
-                "Made an unrecognized api call with the `HostStats` struct as parameters.",
-            )),
-        ))
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,24 +138,24 @@ impl<'r> FromData<'r> for HostStats {
             };
 
             // TEMP NOTE: comment out for manual postman test - sig not verifiable
-            // let decoded_sig = base64::decode(signature).unwrap();
-            // let ed25519_sig = Signature::from_bytes(&decoded_sig).unwrap();
+            let decoded_sig = base64::decode(signature).unwrap();
+            let ed25519_sig = Signature::from_bytes(&decoded_sig).unwrap();
 
             let ed25519_pubkey = decode_pubkey(&host_stats.holoport_id);
 
             // TEMP NOTE: comment out for manual postman test - sig not verifiable
-            // return match ed25519_pubkey.verify_strict(&decoded_data.value, &ed25519_sig) {
-            //     Ok(_) => Success(host_stats),
-            //     Err(_) => Failure((
-            //         Status::Unauthorized,
-            //         ApiError::InvalidSignature(ErrorMessage(
-            //             "Provided host signature does not match signature of signed payload.",
-            //         )),
-            //     )),
-            // };
+            return match ed25519_pubkey.verify_strict(&decoded_data.value, &ed25519_sig) {
+                Ok(_) => Success(host_stats),
+                Err(_) => Failure((
+                    Status::Unauthorized,
+                    ApiError::InvalidSignature(ErrorMessage(
+                        "Provided host signature does not match signature of signed payload.",
+                    )),
+                )),
+            };
 
             // TEMP NOTE: comment in for manual postman test - sig not verifiable
-            return Success(host_stats);
+            // return Success(host_stats);
         }
         Failure((
             Status::BadRequest,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,13 +9,11 @@ use rocket::request::Request;
 use rocket::serde::json::Json;
 use rocket::{self, get, post, State};
 use std::time::SystemTime;
-// use rocket::figment::value::Value;
 
 mod db;
 mod types;
 use types::{
-    ApiError, Capacity, HoloportStatus, HostError, HostSignature, HostStats, HostSummary, Result,
-    Uptime,
+    ApiError, Capacity, ErrorMessage, ErrorMessageInfo, HostStats, HostSummary, Result, Uptime,
 };
 
 #[get("/")]
@@ -52,38 +50,42 @@ async fn capacity(pool: &State<db::AppDbPool>) -> Result<Json<Capacity>> {
     Ok(Json(db::network_capacity(&pool.mongo).await?))
 }
 
-#[post("/stats", data = "<stats>")]
+#[post("/stats", format = "application/json", data = "<stats>")]
 async fn update_stats(stats: HostStats, pool: &State<db::AppDbPool>) -> Result<(), ApiError> {
-    // TODO: Return ApiError instead of unwraps:
+    println!(" ENTERED INTO update_stats");
+
+    // todo: move this into `decode_pubkey` common fn
     let decoded_pubkey = base36::decode(&stats.holoport_id).unwrap();
     let public_key = PublicKey::from_bytes(&decoded_pubkey).unwrap();
 
     // Confirm host exists in registration records
-    db::verify_host(
+    let _ = db::verify_host(
         stats.email,
         to_holochain_encoded_agent_key(&public_key),
         &pool.mongo,
     )
     .await
-    .or_else(|_| {
-        // todo: update error
-        return Err("Failure((Status::Unauthorized, HostError::MissingRecord))");
+    .or_else(|e| {
+        return Err(ApiError::MissingRecord(ErrorMessageInfo(format!(
+            "Provided host's holoport_id is not registered among valid hosts.  Error: {:?}",
+            e
+        ))));
     });
 
-    // Add utc timestamp to stats payload and insert into db
-    let timestamp = SystemTime::now();
-    let holoport_status = HoloportStatus {
-        timestamp,
-        holo_network: stats.holo_network,
-        channel: stats.channel,
-        holoport_model: stats.holoport_model,
-        ssh_success: stats.ssh_status,
-        ip: stats.wan_ip,
-        holoport_id: stats.holoport_id,
-        hosting_info: None,
-        error: None,
-    };
-    db::add_holoport_status(holoport_status, &pool.mongo).await?;
+    // // Add utc timestamp to stats payload and insert into db
+    // let timestamp = format!("{:?}", SystemTime::now());
+    // let holoport_status = HoloportStatus {
+    //     timestamp: format!("{:?}", SystemTime::now()),
+    //     holo_network: stats.holo_network,
+    //     channel: stats.channel,
+    //     holoport_model: stats.holoport_model,
+    //     ssh_success: stats.ssh_status,
+    //     ip: stats.wan_ip,
+    //     holoport_id: stats.holoport_id,
+    //     hosting_info: None,
+    //     error: None,
+    // };
+    // db::add_holoport_status(holoport_status, &pool.mongo).await?;
     Ok(())
 }
 
@@ -94,7 +96,7 @@ async fn main() -> Result<(), rocket::Error> {
         .mount("/", rocket::routes![index])
         .mount(
             "/hosts/",
-            rocket::routes![uptime, list_available, list_registered],
+            rocket::routes![uptime, list_available, list_registered, update_stats],
         )
         .mount("/network/", rocket::routes![capacity])
         .launch()
@@ -103,52 +105,59 @@ async fn main() -> Result<(), rocket::Error> {
 
 #[rocket::async_trait]
 impl<'r> FromData<'r> for HostStats {
-    type Error = HostError;
+    type Error = ApiError;
 
     async fn from_data(request: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
-        // todo: Handle Errors where `unwrap` is used
+        println!(" ENTERED INTO from_data DATA GUARD");
+
         // Use data guard on `/stats` POST to verify host's signature in headers
-        if request.method() == Method::Post && request.uri().path() == "/stats" {
-            // TODO-QUESTION: Ask what the header name in which signature will be passed (using generic 'x-custom-header' for now)
-            let signature = request.headers().get_one("X-Custom-Header");
-            match signature {
-                Some(signature) => HostSignature(signature.to_string()),
-                None => return Failure((Status::Unauthorized, HostError::MissingSignature)),
+        if request.method() == Method::Post && request.uri().path() == "/hosts/stats" {
+            let signature = match request.headers().get_one("x-hpos-signature") {
+                Some(signature) => signature.to_string(),
+                None => {
+                    return Failure((
+                        Status::Unauthorized,
+                        ApiError::MissingSignature(ErrorMessage(
+                            "Host's hpos signature was not located in the request headers.",
+                        )),
+                    ))
+                }
             };
 
-            // todo: Move this into a try_from Data into HostStats:
-            let body = data
-                .open(data::ByteUnit::max_value())
-                .stream_to(tokio::io::stdout())
-                .await
-                .unwrap();
-            let host_stats: HostStats = match serde_json::from_str(&format!("{}", body)) {
+            let byte_unit_data = data.open(data::ByteUnit::max_value());
+            let decoded_data = byte_unit_data.into_bytes().await.unwrap();
+            let host_stats: HostStats = match serde_json::from_slice(&decoded_data.value) {
                 Ok(a) => a,
-                Err(_) => return Failure((Status::UnprocessableEntity, HostError::InvalidPayload)),
+                Err(e) => {
+                    return Failure((
+                        Status::UnprocessableEntity,
+                        ApiError::InvalidPayload(ErrorMessageInfo(
+                            format!("Provided payload to `hosts/stats` does not match expected payload. Error: {:?}", e),
+                        )),
+                    ));
+                }
             };
 
-            // TODO-QUESTION:Ask what encoding is being used (assuming BASE64 right now)
-            let decoded_sig = base64::decode(signature.unwrap()).unwrap();
-            let ed25519_sig = Signature::from_bytes(&decoded_sig).unwrap();
-            let decoded_data = data
-                .open(data::ByteUnit::max_value())
-                .into_bytes()
-                .await
-                .unwrap();
+            println!("Sig: {:?}", signature);
+            // let decoded_sig = base64::decode(signature).unwrap();
+            // let ed25519_sig = Signature::from_bytes(&decoded_sig).unwrap();
 
+            // todo: move this into `decode_pubkey` common fn
             let decoded_pubkey = base36::decode(&host_stats.holoport_id).unwrap();
             let public_key = PublicKey::from_bytes(&decoded_pubkey).unwrap();
-            public_key
-                .verify_strict(&decoded_data.value, &ed25519_sig)
-                .or_else(|_| {
-                    // todo: fix error reference
-                    return Err("Failure((Status::Unauthorized, HostError::InvalidSignature))");
-                });
-
+            println!(" public_key: {:?}", public_key);
+            println!(" host_stats: {:?}", host_stats);
+            // return match public_key.verify_strict(&decoded_data.value, &ed25519_sig) {
+            //     Ok(_) => Success(host_stats),
+            //     Err(_) => Failure((Status::Unauthorized, ApiError::InvalidSignature(ErrorMessage("Provided host signature does not match signature of signed payload.")))),
+            // };
             return Success(host_stats);
         }
-
-        // Otherwise no data guard check needed
-        Forward(data)
+        Failure((
+            Status::BadRequest,
+            ApiError::BadRequest(ErrorMessage(
+                "Made an unrecognized call with HostStats parameters.",
+            )),
+        ))
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,8 +7,6 @@ use bson::oid::ObjectId;
 use mongodb::{bson, error::Error};
 use rocket::response::Debug;
 
-use std::time::SystemTime;
-
 // [rocket::response::Debug](https://api.rocket.rs/v0.5-rc/rocket/response/struct.Debug.html) implements Responder to Error
 pub type Result<T, E = Debug<Error>> = std::result::Result<T, E>;
 
@@ -103,28 +101,25 @@ pub struct Assignment {
     pub name: String,
 }
 
-#[derive(Responder)]
+#[derive(Responder, Debug)]
 #[response(status = 400)]
-pub struct BadRequest(pub &'static str);
+pub struct ErrorMessage(pub &'static str);
 
-#[derive(Responder)]
+#[derive(Responder, Debug)]
+pub struct ErrorMessageInfo(pub String);
+
+#[derive(Responder, Debug)]
 pub enum ApiError {
-    BadRequest(BadRequest),
+    BadRequest(ErrorMessage),
     Database(Debug<Error>),
-}
-
-pub struct HostSignature(String);
-
-#[derive(Debug)]
-pub enum HostError {
-    MissingRecord,
-    MissingSignature,
-    InvalidSignature,
-    InvalidPayload,
+    InvalidPayload(ErrorMessageInfo),
+    MissingRecord(ErrorMessageInfo),
+    MissingSignature(ErrorMessage),
+    InvalidSignature(ErrorMessage),
 }
 
 // Input type for /hosts/stats endpoint
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct HostStats {
@@ -147,7 +142,7 @@ pub struct HoloportStatus {
     pub holoport_id: String,
     #[serde(rename = "IP")]
     pub ip: String,
-    pub timestamp: SystemTime,
+    pub timestamp: String,
     pub ssh_success: bool,
     pub holo_network: Option<String>,
     pub channel: Option<String>,
@@ -156,28 +151,28 @@ pub struct HoloportStatus {
     pub error: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Debug)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct NumberInt {
     number_int: u16,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct NumberLong {
     number_long: u64,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct DateCreated {
     date: NumberLong,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct AgentPubKeys {
@@ -185,7 +180,7 @@ pub struct AgentPubKeys {
     role: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct RegistrationCode {
@@ -195,7 +190,7 @@ pub struct RegistrationCode {
 }
 
 // Data schema in database `opsconsoledb`, collection `registration`
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct HostRegistration {

--- a/src/types.rs
+++ b/src/types.rs
@@ -110,7 +110,7 @@ pub struct HostStats {
     pub ssh_status: Option<bool>,
     pub zt_ip: Option<String>,
     pub wan_ip: Option<String>,
-    pub holoport_id_base36: String,
+    pub holoport_id: String,
     pub timestamp: Option<String>,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,6 +10,24 @@ use rocket::response::Debug;
 // [rocket::response::Debug](https://api.rocket.rs/v0.5-rc/rocket/response/struct.Debug.html) implements Responder to Error
 pub type Result<T, E = Debug<Error>> = std::result::Result<T, E>;
 
+#[derive(Responder, Debug)]
+#[response(status = 400)]
+pub struct ErrorMessage(pub &'static str);
+
+#[derive(Responder, Debug)]
+#[response(status = 400)]
+pub struct ErrorMessageInfo(pub String);
+
+#[derive(Responder, Debug)]
+pub enum ApiError {
+    BadRequest(ErrorMessage),
+    Database(Debug<Error>),
+    InvalidPayload(ErrorMessageInfo),
+    MissingRecord(ErrorMessageInfo),
+    MissingSignature(ErrorMessage),
+    InvalidSignature(ErrorMessage),
+}
+
 // Return type for /network/capacity endpoint
 #[derive(Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
@@ -99,24 +117,6 @@ pub struct HostSummary {
 #[serde(rename_all = "camelCase")]
 pub struct Assignment {
     pub name: String,
-}
-
-#[derive(Responder, Debug)]
-#[response(status = 400)]
-pub struct ErrorMessage(pub &'static str);
-
-#[derive(Responder, Debug)]
-#[response(status = 400)]
-pub struct ErrorMessageInfo(pub String);
-
-#[derive(Responder, Debug)]
-pub enum ApiError {
-    BadRequest(ErrorMessage),
-    Database(Debug<Error>),
-    InvalidPayload(ErrorMessageInfo),
-    MissingRecord(ErrorMessageInfo),
-    MissingSignature(ErrorMessage),
-    InvalidSignature(ErrorMessage),
 }
 
 // Input type for /hosts/stats endpoint

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,9 @@
+use base64;
+use ed25519_dalek::Signature;
+use rocket::data::{self, Data, FromData};
+use rocket::http::{Method, Status};
+use rocket::outcome::Outcome::*;
+use rocket::request::Request;
 use rocket::{
     response::Responder,
     serde::{Deserialize, Serialize},
@@ -6,6 +12,8 @@ use rocket::{
 use bson::oid::ObjectId;
 use mongodb::{bson, error::Error};
 use rocket::response::Debug;
+
+use super::db;
 
 // [rocket::response::Debug](https://api.rocket.rs/v0.5-rc/rocket/response/struct.Debug.html) implements Responder to Error
 pub type Result<T, E = Debug<Error>> = std::result::Result<T, E>;
@@ -112,6 +120,78 @@ pub struct HostStats {
     pub wan_ip: Option<String>,
     pub holoport_id: String,
     pub timestamp: Option<String>,
+}
+
+#[rocket::async_trait]
+impl<'r> FromData<'r> for HostStats {
+    type Error = ApiError;
+
+    async fn from_data(request: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
+        // Use data guard on `/stats` POST to verify host's signature in headers
+        if request.method() == Method::Post && request.uri().path() == "/hosts/stats" {
+            let signature = match request.headers().get_one("x-hpos-signature") {
+                Some(signature) => signature.to_string(),
+                None => {
+                    return Failure((
+                        Status::Unauthorized,
+                        ApiError::MissingSignature(Error401::Message(
+                            "Host's hpos signature was not located in the request headers.",
+                        )),
+                    ))
+                }
+            };
+
+            let byte_unit_data = data.open(data::ByteUnit::max_value());
+            let decoded_data = byte_unit_data.into_bytes().await.unwrap();
+            let host_stats: HostStats = match serde_json::from_slice(&decoded_data.value) {
+                Ok(hs) => hs,
+                Err(e) => {
+                    return Failure((
+                        Status::UnprocessableEntity,
+                        ApiError::InvalidPayload(Error400::Info(
+                            format!("Provided payload to `hosts/stats` does not match expected payload. Error: {:?}", e),
+                        )),
+                    ));
+                }
+            };
+
+            // TEMP NOTE: comment out for manual postman test - sig not verifiable
+            let decoded_sig = match base64::decode(signature) {
+                Ok(ds) => ds,
+                Err(e) => {
+                    return Failure((
+                        Status::UnprocessableEntity,
+                        ApiError::InvalidSignature(Error401::Info(
+                            format!("Provided signature to `hosts/stats` does not have the expected encoding. Error: {:?}", e),
+                        )),
+                    ));
+                }
+            };
+            let ed25519_sig = Signature::from_bytes(&decoded_sig).unwrap();
+
+            let ed25519_pubkey = db::decode_pubkey(&host_stats.holoport_id);
+
+            // TEMP NOTE: comment out for manual postman test - sig not verifiable
+            return match ed25519_pubkey.verify_strict(&decoded_data.value, &ed25519_sig) {
+                Ok(_) => Success(host_stats),
+                Err(_) => Failure((
+                    Status::Unauthorized,
+                    ApiError::InvalidSignature(Error401::Message(
+                        "Provided host signature does not match signature of signed payload.",
+                    )),
+                )),
+            };
+
+            // TEMP NOTE: comment in for manual postman test - sig not verifiable
+            // return Success(host_stats);
+        }
+        Failure((
+            Status::BadRequest,
+            ApiError::BadRequest(Error400::Message(
+                "Made an unrecognized api call with the `HostStats` struct as parameters.",
+            )),
+        ))
+    }
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -74,7 +74,7 @@ pub struct Host {
     pub assigned_to: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct HostSummary {
@@ -106,6 +106,7 @@ pub struct Assignment {
 pub struct ErrorMessage(pub &'static str);
 
 #[derive(Responder, Debug)]
+#[response(status = 400)]
 pub struct ErrorMessageInfo(pub String);
 
 #[derive(Responder, Debug)]
@@ -119,7 +120,7 @@ pub enum ApiError {
 }
 
 // Input type for /hosts/stats endpoint
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct HostStats {
@@ -151,28 +152,28 @@ pub struct HoloportStatus {
     pub error: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Default, Debug)]
+#[derive(Serialize, Deserialize, Default)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct NumberInt {
     number_int: u16,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct NumberLong {
     number_long: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct DateCreated {
     date: NumberLong,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct AgentPubKeys {
@@ -180,7 +181,7 @@ pub struct AgentPubKeys {
     role: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct RegistrationCode {
@@ -190,7 +191,7 @@ pub struct RegistrationCode {
 }
 
 // Data schema in database `opsconsoledb`, collection `registration`
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct HostRegistration {

--- a/src/types.rs
+++ b/src/types.rs
@@ -120,36 +120,20 @@ pub struct Assignment {
 }
 
 // Input type for /hosts/stats endpoint
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(crate = "rocket::serde")]
-#[serde(rename_all = "camelCase")]
-pub struct HostStats {
-    pub email: String, // >> discuss adding email to `HostStats` schema to use as filter instead of pubkey/hostid
-    pub holo_network: Option<String>,
-    pub channel: Option<String>,
-    pub holoport_model: Option<String>,
-    pub ssh_status: bool, // why is this not passed in as ssh_success to match the schema
-    pub zt_ip: String,    // what are we using this value for? > should it be added to the schema?
-    pub wan_ip: String, // is this going to be the correct ip of the hp? - or does it still need to be configured with this as input?
-    pub holoport_id: String,
-}
-
 // Data schema in collection `holoports_status`
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
-pub struct HoloportStatus {
-    #[serde(rename = "name")]
-    pub holoport_id: String,
-    #[serde(rename = "IP")]
-    pub ip: String,
-    pub timestamp: String,
-    pub ssh_success: bool,
+pub struct HostStats {
     pub holo_network: Option<String>,
     pub channel: Option<String>,
     pub holoport_model: Option<String>,
-    pub hosting_info: Option<String>,
-    pub error: Option<String>,
+    pub ssh_status: bool,
+    pub zt_ip: String,
+    pub wan_ip: String,
+    pub holoport_id_base36: String,
+    pub timestamp: String,
+    pub email: String, // >> discuss adding email to `HostStats` schema to use as filter instead of pubkey/hostid
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -119,7 +119,7 @@ pub struct HostStats {
     pub zt_ip: Option<String>,
     pub wan_ip: Option<String>,
     pub holoport_id: String,
-    pub timestamp: Option<String>,
+    pub timestamp: Option<i64>,
 }
 
 #[rocket::async_trait]


### PR DESCRIPTION
### Updates:
 - adds `/hosts/stats/` post endpoint
 - updates `holoports_status` schema to match the data sent by the `net-stats-daemon`:
 ```
  holoNetwork  # can be one of devNet, alphaNet, flexNet...
  channel      # nix-channel that HPOS is following
  holoportModel        # HP or HP+
  sshStatus    # is SSH enabled?
  ztIp         # IP address on Zerotier network
  wanIp        # IPv4 address on internet
  holoportIdBase36   # base36 encoded public key of the host
  timestamp    # updated on API server
```