### PR TITLE
#41 / recieve version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,16 @@ POST
 payload:
 ```json
 {
-  "holoNetwork": <string>  # can be one of devNet, alphaNet, flexNet...
-  "channel" : <string>     # nix-channel that HPOS is following
-  "holoportModel": <string> # HP or HP+
-  "sshStatus": <bool>      # is SSH enabled?
-  "ztIp": <string>         # IP address on Zerotier network
-  "wanIp": <string>        # IPv4 address on internet
-  "holoportId": <string>   # base36 encoded public key of the host
-  "timestamp": <string>    # updated on API server
+  "holoNetwork":    <string>  # can be one of devNet, alphaNet, flexNet...
+  "channel" :       <string>  # nix-channel that HPOS is following
+  "holoportModel":  <string>  # HP or HP+
+  "sshStatus":      <bool>    # is SSH enabled?
+  "ztIp":           <string>  # IP address on Zerotier network
+  "wanIp":          <string>  # IPv4 address on internet
+  "holoportId":     <string>  # base36 encoded public key of the host
+  "timestamp":      <string>  # updated on API server
+  "hposVersion":    <string>  # the git revision channel that HPOS has downloaded
+  "channelVersion": <string>  # the git revision that HPOS is currently running
 }
 ```
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -200,7 +200,7 @@ pub async fn add_holoport_status(hs: HostStats, db: &Client) -> Result<(), ApiEr
         "timestamp": hs.timestamp,
         "hposAppList": hpos_app_list,
         "channelVersion": hs.channel_version,
-        "holoportVersion": hs.holoport_version,
+        "hposVersion": hs.hpos_version,
     };
     match hp_status.insert_one(val, None).await {
         Ok(_) => Ok(()),

--- a/src/db.rs
+++ b/src/db.rs
@@ -267,18 +267,11 @@ pub async fn add_host_stats(stats: HostStats, pool: &State<AppDbPool>) -> Result
 
     // Add utc timestamp to stats payload and insert into db
     let holoport_status = HostStats {
-        holo_network: stats.holo_network,
-        channel: stats.channel,
-        holoport_model: stats.holoport_model,
-        ssh_status: stats.ssh_status,
-        zt_ip: stats.zt_ip,
-        wan_ip: stats.wan_ip,
-        holoport_id: stats.holoport_id,
         timestamp: SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .ok()
             .map(|t| i64::try_from(t.as_secs()).ok().unwrap_or(0)),
-        hpos_app_list: stats.hpos_app_list,
+        ..stats
     };
     add_holoport_status(holoport_status, &pool.mongo).await?;
     Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -123,6 +123,8 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSt
                 "wanIp": {"$first": "$wanIp"},
                 "timestamp": {"$first": "$timestamp"},
                 "hposAppList": {"$first": "$hposAppList"},
+                "channelVersion": {"$first": "$channelVersion"},
+                "hposVersion": {"$first": "$hposVersion"},
             }
         },
         doc! {
@@ -137,6 +139,8 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSt
                 "wanIp": "$wanIp",
                 "timestamp":"$timestamp",
                 "hposAppList": "$hposAppList",
+                "channelVersion": "$channelVersion",
+                "hposVersion": "$hposVersion",
               }
         },
     ];

--- a/src/db.rs
+++ b/src/db.rs
@@ -199,6 +199,8 @@ pub async fn add_holoport_status(hs: HostStats, db: &Client) -> Result<(), ApiEr
         "holoportId": hs.holoport_id,
         "timestamp": hs.timestamp,
         "hposAppList": hpos_app_list,
+        "channelVersion": hs.channel_version,
+        "holoportVersion": hs.holoport_version,
     };
     match hp_status.insert_one(val.clone(), None).await {
         Ok(_) => Ok(()),

--- a/src/db.rs
+++ b/src/db.rs
@@ -202,7 +202,7 @@ pub async fn add_holoport_status(hs: HostStats, db: &Client) -> Result<(), ApiEr
         "channelVersion": hs.channel_version,
         "holoportVersion": hs.holoport_version,
     };
-    match hp_status.insert_one(val.clone(), None).await {
+    match hp_status.insert_one(val, None).await {
         Ok(_) => Ok(()),
         Err(e) => Err(ApiError::Database(Debug(e))),
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -237,16 +237,10 @@ async fn add_host_stats(pass_valid_signature: bool) {
 
     // Create payload, sign payload, and call `/host/stats` endpoint, passing valid signature within call header
     let payload = HostStats {
-        holo_network: None,
-        channel: None,
-        holoport_model: None,
-        ssh_status: None,
-        zt_ip: None,
-        wan_ip: None,
         // Note: The `holoport_id` must be the base_36 encoded version of the `host_registration.registration_code[i].agent_pub_keys[i].pub_key`
         holoport_id: "1h2di6px7otkjwudmycadu5teaywao46jelpegg7jujncbcbzs".to_string(),
-        timestamp: None,
         hpos_app_list: Some(hpos_app_list),
+        ..Default::default()
     };
 
     let signature;

--- a/src/types.rs
+++ b/src/types.rs
@@ -111,7 +111,7 @@ pub struct Assignment {
 
 // Input type for /hosts/stats endpoint
 // Data schema in collection `holoport_status`
-// Note: We wrap each feild value in Option<T> because if the HPOS `netstatd` fails to collect data, it will send null in failed field.
+// Note: We wrap each field value in Option<T> because if the HPOS `netstatd` fails to collect data, it will send null in failed field.
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -112,7 +112,7 @@ pub struct Assignment {
 // Input type for /hosts/stats endpoint
 // Data schema in collection `holoport_status`
 // Note: We wrap each field value in Option<T> because if the HPOS `netstatd` fails to collect data, it will send null in failed field.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct HostStats {

--- a/src/types.rs
+++ b/src/types.rs
@@ -125,6 +125,8 @@ pub struct HostStats {
     pub holoport_id: String,
     pub timestamp: Option<i64>,
     pub hpos_app_list: Option<HashMap<InstalledAppId, AppStatusFilter>>,
+    pub channel_version: Option<String>,
+    pub holoport_version: Option<String>,
 }
 
 #[rocket::async_trait]

--- a/src/types.rs
+++ b/src/types.rs
@@ -126,7 +126,7 @@ pub struct HostStats {
     pub timestamp: Option<i64>,
     pub hpos_app_list: Option<HashMap<InstalledAppId, AppStatusFilter>>,
     pub channel_version: Option<String>,
-    pub holoport_version: Option<String>,
+    pub hpos_version: Option<String>,
 }
 
 #[rocket::async_trait]


### PR DESCRIPTION
This adds the functions necessary to receive the [version information](https://github.com/Holo-Host/holo-nixpkgs/pull/1205) from  [Holo-Host/net-stats-daemon](https://github.com/Holo-Host/net-stats-daemon) and add it to the `BSON` document that is pushed to the DB.

---

Addresses part of: https://github.com/Holo-Host/bugs-n-issues/issues/41
Depends on: https://github.com/Holo-Host/holo-nixpkgs/pull/1205
Additional Work:  https://github.com/Holo-Host/net-stats-daemon/pull/6