### PR TITLE
`list_available` endpoint reads holoport status from zerotier collection as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,27 @@ GET
 
 days = Cut off time. Records older than this will be ignored.
 
+This endpoint returns all the holoports on the holo network as seen by both zerotier network controller and Holoport's netstatsd. Data from both sources is merged and analyzed for possible errors. All the errors are reported in form of an array under field `errors`.
+
 #### `200 OK`
 
 ```json
 [
   {
-    "_id": "string",
-    "IP": "string",
-    "timestamp": 0,
-    "sshSuccess": true,
-    "holoNetwork": "string",
-    "channel": "string",
-    "holoportModel": "string",
-    "hostingInfo": "string",
-    "error": "string",
-    "alphaProgram": true,
-    "assignedTo": "string"
+    "zerotier_ip": "172.26.215.31",                                     # IP address on Zerotier network
+    "wan_ip": "77.12.0.3",                                              # IPv4 address on internet
+    "last_zerotier_online": 123456678810,                               # timestamp of the last contact of the host with Zerotier network controller
+    "last_netstatsd_reported": 123456678834,                            # timestamp of the last update from netstatsd
+    "holoport_id": "5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4", # base36 encoded public key of the host
+    "registered_email": "alex@email.qq",                                # email address used at registration
+    "holo_network": "devNet",                                           # can be one of devNet, alphaNet, flexNet...
+    "channel": "develop",                                               # nix-channel that HPOS is following
+    "holoport_model": "holoport",                                       # HP or HP+
+    "ssh_status": true,                                                 # is SSH enabled?
+    "hpos_app_list": [],                                                # list of hosted happs as reported by netstatsd
+    "channel_version": "89ec8aaef697b4741e6f0cefc4a9f8e7cc1e18dd",      # the git revision that HPOS is currently running
+    "hpos_version": "89ec8aaef697b4741e6f0cefc4a9f8e7cc1e18dd",         # the git revision channel that HPOS has downloaded
+    "errors": []
   }
 ]
 ```

--- a/src/db.rs
+++ b/src/db.rs
@@ -41,7 +41,7 @@ pub async fn ping_database(db: &Client) -> Result<String> {
     db.database("host_statistics")
         .run_command(doc! {"ping": 1}, None)
         .await?;
-    Ok(format!("Connected to db. v0.0.2"))
+    Ok("Connected to db. v0.0.2".to_string())
 }
 
 // Find a value of uptime for host identified by its name in a collection `performance_summary`
@@ -305,11 +305,11 @@ pub async fn add_host_stats(stats: HostStats, pool: &State<AppDbPool>) -> Result
     // Confirm host exists in registration records
     let _ = verify_host(to_holochain_encoded_agent_key(&ed25519_pubkey), &pool.mongo)
         .await
-        .or_else(|e| {
-            return Err(ApiError::MissingRecord(Error404::Info(format!(
+        .map_err(|e| {
+            ApiError::MissingRecord(Error404::Info(format!(
                 "Provided host's holoport_id is not registered among valid hosts.  Error: {:?}",
                 e
-            ))));
+            )))
         });
 
     // Add utc timestamp to stats payload and insert into db

--- a/src/db.rs
+++ b/src/db.rs
@@ -12,8 +12,8 @@ use ed25519_dalek::PublicKey;
 use hpos_config_core::public_key::to_holochain_encoded_agent_key;
 
 use crate::types::{
-    ApiError, Capacity, Error400, Error404, HostRegistration, HostStats, Performance,
-    Result, Uptime, ZerotierMember,
+    ApiError, Capacity, Error400, Error404, HostRegistration, HostStats, Performance, Result,
+    Uptime, ZerotierMember,
 };
 
 const DAYS_TOO_LARGE: Error400 =

--- a/src/db.rs
+++ b/src/db.rs
@@ -100,9 +100,8 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSt
 
     let pipeline = vec![
         doc! {
-            // only successful ssh results in last <cutoff> days
+            // get entries within last <cutoff> days
             "$match": {
-                "sshStatus": true,
                 "timestamp": {"$gte": cutoff_ms}
             }
         },
@@ -113,6 +112,7 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSt
             }
         },
         doc! {
+            // Group by holoport ID and return first (the most recent) record
             "$group": {
                 "_id": "$holoportId",
                 "holoNetwork": {"$first": "$holoNetwork"},
@@ -128,6 +128,7 @@ pub async fn list_available_hosts(db: &Client, cutoff: u64) -> Result<Vec<HostSt
             }
         },
         doc! {
+            // Rename key _id to holoportId
             "$project": {
                 "_id": 0,
                 "holoportId": "$_id",

--- a/src/db.rs
+++ b/src/db.rs
@@ -45,12 +45,12 @@ pub async fn ping_database(db: &Client) -> Result<String> {
 }
 
 // Delete from host_statistics.holoport_status documents with
-// timestamp field older than 60 days. Used for database cleanup
+// timestamp field older than 30 days. Used for database cleanup
 pub async fn cleanup_database(db: &Client) -> Result<String, ApiError> {
     let hp_status: Collection<HostStats> =
         db.database("host_statistics").collection("holoport_status");
 
-    let cutoff_ms = match get_cutoff_timestamp(60) {
+    let cutoff_ms = match get_cutoff_timestamp(30) {
         Some(x) => x,
         None => return Err(ApiError::BadRequest(DAYS_TOO_LARGE)),
     };

--- a/src/db.rs
+++ b/src/db.rs
@@ -62,7 +62,10 @@ pub async fn cleanup_database(db: &Client) -> Result<String, ApiError> {
     };
 
     match hp_status.delete_many(val, None).await {
-        Ok(res) => Ok(format!("Deleted {} documents from holoport_status collection", res.deleted_count)),
+        Ok(res) => Ok(format!(
+            "Deleted {} documents from holoport_status collection",
+            res.deleted_count
+        )),
         Err(e) => Err(ApiError::Database(Debug(e))),
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -62,7 +62,7 @@ pub async fn cleanup_database(db: &Client) -> Result<String, ApiError> {
     };
 
     match hp_status.delete_many(val, None).await {
-        Ok(res) => Ok(format!("Deleted {} documents", res.deleted_count)),
+        Ok(res) => Ok(format!("Deleted {} documents from holoport_status collection", res.deleted_count)),
         Err(e) => Err(ApiError::Database(Debug(e))),
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,8 +1,4 @@
-use crate::types::{
-  ApiError, HostInfo, HostStats,
-  Result, ZerotierMember,
-};
-
+use crate::types::{ApiError, HostInfo, HostStats, Result, ZerotierMember};
 
 /// Returns all available hosts listed in `host_statistics.holoport_status`
 /// and `host_statistics.latest_raw_snap` collections. Function merges two data sets
@@ -10,111 +6,115 @@ use crate::types::{
 /// reports to user in `errors` field
 /// Hosts losted in `host_statistics.holoport_status` but not listed in `host_statistics.latest_raw_snap`
 /// are also marked as flawed
-pub async fn list_available_hosts(hosts: Vec<HostStats>, members: Vec<ZerotierMember>) -> Result<Vec<HostInfo>, ApiError> {
-  Ok(merge_host_info(hosts, members))
+pub async fn list_available_hosts(
+    hosts: Vec<HostStats>,
+    members: Vec<ZerotierMember>,
+) -> Result<Vec<HostInfo>, ApiError> {
+    Ok(merge_host_info(hosts, members))
 }
 
 /// Takes each `member` and finds corresponding `host` by matching on `zerotier_ip`.
 /// Builds HostInfo based on this data and reports errors in case of inconsistency.
 /// Remaining hosts are added as HostInfo with error field set
-fn merge_host_info(
-  mut hosts: Vec<HostStats>,
-  mut members: Vec<ZerotierMember>,
-) -> Vec<HostInfo> {
-  let mut host_info_vec: Vec<HostInfo> = vec![];
+fn merge_host_info(mut hosts: Vec<HostStats>, mut members: Vec<ZerotierMember>) -> Vec<HostInfo> {
+    let mut host_info_vec: Vec<HostInfo> = vec![];
 
-  // this loop iretates over all members and tries to find a matching host
-  // If it finds a matching host it removes it from hosts
-  while let Some(member) = members.pop() {
-      let mut errors: Vec<String> = vec![];
-      let host = find_in_hosts(&mut hosts, &member.zerotier_ip, &mut errors);
-      let holoport_id = resolve_holoport_id(host.holoport_id, member.name, &mut errors);
+    // this loop iretates over all members and tries to find a matching host
+    // If it finds a matching host it removes it from hosts
+    while let Some(member) = members.pop() {
+        let mut errors: Vec<String> = vec![];
+        let host = find_in_hosts(&mut hosts, &member.zerotier_ip, &mut errors);
+        let holoport_id = resolve_holoport_id(host.holoport_id, member.name, &mut errors);
 
-      host_info_vec.push(HostInfo {
-          zerotier_ip: member.zerotier_ip,
-          wan_ip: member.physical_address,
-          last_zerotier_online: zero_to_none(member.last_online), // 0 means never seen which will print as null
-          last_netstatsd_reported: host.timestamp,
-          holoport_id,
-          registered_email: member.description,
-          holo_network: host.holo_network,
-          channel: host.channel,
-          holoport_model: host.holoport_model,
-          ssh_status: host.ssh_status,
-          hpos_app_list: host.hpos_app_list,
-          channel_version: host.channel_version,
-          hpos_version: host.hpos_version,
-          errors,
-      });
-  }
+        host_info_vec.push(HostInfo {
+            zerotier_ip: member.zerotier_ip,
+            wan_ip: member.physical_address,
+            last_zerotier_online: zero_to_none(member.last_online), // 0 means never seen which will print as null
+            last_netstatsd_reported: host.timestamp,
+            holoport_id,
+            registered_email: member.description,
+            holo_network: host.holo_network,
+            channel: host.channel,
+            holoport_model: host.holoport_model,
+            ssh_status: host.ssh_status,
+            hpos_app_list: host.hpos_app_list,
+            channel_version: host.channel_version,
+            hpos_version: host.hpos_version,
+            errors,
+        });
+    }
 
-  // If a host remainded in hosts then it was not present in members
-  // which means that either this zt_ip was reported also by some other holoport
-  // or that this zt_ip was not present in members at all
-  // In both cases we need to set an error
-  while let Some(host) = hosts.pop() {
-    host_info_vec.push(HostInfo {
-      zerotier_ip: host.zt_ip.clone(),
-      wan_ip: None,
-      last_zerotier_online: None,
-      last_netstatsd_reported: host.timestamp,
-      holoport_id: Some(host.holoport_id),
-      registered_email: None,
-      holo_network: host.holo_network,
-      channel: host.channel,
-      holoport_model: host.holoport_model,
-      ssh_status: host.ssh_status,
-      hpos_app_list: host.hpos_app_list,
-      channel_version: host.channel_version,
-      hpos_version: host.hpos_version,
-      errors: vec![format!("This host reported its zerotier IP as {} but Zerotier Central has no knowledge of it", host.zt_ip.unwrap_or("None".into()))],
-  });
-  }
+    // If a host remainded in hosts then it was not present in members
+    // which means that either this zt_ip was reported also by some other holoport
+    // or that this zt_ip was not present in members at all
+    // In both cases we need to set an error
+    while let Some(host) = hosts.pop() {
+        host_info_vec.push(HostInfo {
+            zerotier_ip: host.zt_ip.clone(),
+            wan_ip: None,
+            last_zerotier_online: None,
+            last_netstatsd_reported: host.timestamp,
+            holoport_id: Some(host.holoport_id),
+            registered_email: None,
+            holo_network: host.holo_network,
+            channel: host.channel,
+            holoport_model: host.holoport_model,
+            ssh_status: host.ssh_status,
+            hpos_app_list: host.hpos_app_list,
+            channel_version: host.channel_version,
+            hpos_version: host.hpos_version,
+            errors: vec![format!("This host reported its zerotier IP as {} but Zerotier Central has no knowledge of it", host.zt_ip.unwrap_or("None".into()))],
+        });
+    }
 
-  host_info_vec
+    host_info_vec
 }
 
 fn zero_to_none(num: i64) -> Option<i64> {
-  if num == 0 {
-      return None;
-  }
-  Some(num)
+    if num == 0 {
+        return None;
+    }
+    Some(num)
 }
 
 /// Finds in `hosts` a host with `zerotier_ip` and once found removes it from `hosts`. If none found returns empty `HostStats`.
-/// Sets an error in an array if `zerotier_ip` is `None`
+/// Sets an error in an `errors` if `zerotier_ip` is `None`
 fn find_in_hosts(
-  hosts: &mut Vec<HostStats>,
-  zerotier_ip: &Option<String>,
-  errors: &mut Vec<String>,
+    hosts: &mut Vec<HostStats>,
+    zerotier_ip: &Option<String>,
+    errors: &mut Vec<String>,
 ) -> HostStats {
-  if zerotier_ip.is_none() {
-      errors.push(format!(
-      "This holoport does not have IP assigned in ZT network"
-      ));
-      // Return empty HostStats
-      return HostStats::default();
-  }
-  if let Some(index) = hosts.iter().position(|host| host.zt_ip == *zerotier_ip) {
-    return hosts.swap_remove(index);
-  } else {
-    errors.push(format!(
+    if zerotier_ip.is_none() {
+        errors.push(format!(
+            "This holoport does not have IP assigned in ZT network"
+        ));
+        // Return empty HostStats
+        return HostStats::default();
+    }
+    if let Some(index) = hosts.iter().position(|host| host.zt_ip == *zerotier_ip) {
+        return hosts.swap_remove(index);
+    } else {
+        errors.push(format!(
         "None of the holoports reporting to host_statistics.holoport_status has zerotier ip {:?}",
         zerotier_ip
     ));
-    HostStats::default()
-  }
+        HostStats::default()
+    }
 }
 
-/// Compare holoport ids reported by zerotier and netstatsd, report an error in case of mismatch
+/// Compare holoport ids reported by zerotier and netstatsd,
+/// report an error in case of mismatch and return the one reported by netstatsd
 fn resolve_holoport_id(
-  holoport_id: String,
-  zerotier_name: Option<String>,
-  errors: &mut Vec<String>,
+    holoport_id: String,
+    zerotier_name: Option<String>,
+    errors: &mut Vec<String>,
 ) -> Option<String> {
-  if zerotier_name.is_none() || Some(holoport_id.clone()) != zerotier_name {
-      errors.push(format!("Mismatched holoport ID between data from zerotier ({:?}) and netstatsd ({:?})", zerotier_name, &holoport_id));
-  }
+    if zerotier_name.is_none() || Some(holoport_id.clone()) != zerotier_name {
+        errors.push(format!(
+            "Mismatched holoport ID between data from zerotier ({:?}) and netstatsd ({:?})",
+            zerotier_name, &holoport_id
+        ));
+    }
 
-  Some(holoport_id)
+    Some(holoport_id)
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -63,7 +63,10 @@ fn merge_host_info(mut hosts: Vec<HostStats>, mut members: Vec<ZerotierMember>) 
             hpos_app_list: host.hpos_app_list,
             channel_version: host.channel_version,
             hpos_version: host.hpos_version,
-            errors: vec![format!("Netstatsd reported zerotier IP as {} but Zerotier Central has no knowledge of it", host.zt_ip.unwrap_or("None".into()))],
+            errors: vec![format!(
+                "Netstatsd reported zerotier IP as {} but Zerotier Central has no knowledge of it",
+                host.zt_ip.unwrap_or("None".into())
+            )],
         });
     }
 
@@ -85,14 +88,12 @@ fn find_in_hosts(
     errors: &mut Vec<String>,
 ) -> HostStats {
     if zerotier_ip.is_none() {
-        errors.push(format!(
-            "This holoport does not have IP assigned in ZT network"
-        ));
+        errors.push("This holoport does not have IP assigned in ZT network".to_string());
         // Return empty HostStats
         return HostStats::default();
     }
     if let Some(index) = hosts.iter().position(|host| host.zt_ip == *zerotier_ip) {
-        return hosts.swap_remove(index);
+        hosts.swap_remove(index)
     } else {
         errors.push(format!(
         "IP {} is listed on Zerotier as active, but none fo the holoports reports that way via netstatsd",
@@ -115,7 +116,8 @@ fn resolve_holoport_id(
     if zerotier_name.is_none() || Some(holoport_id.clone()) != zerotier_name {
         errors.push(format!(
             "Mismatched holoport ID between data from zerotier ({}) and netstatsd ({})",
-            zerotier_name.unwrap_or("???".into()), &holoport_id
+            zerotier_name.unwrap_or("???".into()),
+            &holoport_id
         ));
     }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -96,7 +96,7 @@ fn find_in_hosts(
         hosts.swap_remove(index)
     } else {
         errors.push(format!(
-        "IP {} is listed on Zerotier as active, but none fo the holoports reports that way via netstatsd",
+        "IP {} is listed in Zerotier Central as active, but no holoport reported this IP via netstatsd within queried timeframe",
         zerotier_ip.as_ref().unwrap_or(&"???".to_string())
     ));
         HostStats::default()

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,0 +1,120 @@
+use crate::types::{
+  ApiError, HostInfo, HostStats,
+  Result, ZerotierMember,
+};
+
+
+/// Returns all available hosts listed in `host_statistics.holoport_status`
+/// and `host_statistics.latest_raw_snap` collections. Function merges two data sets
+/// with zerotierIp as a primary key and in case of merge conflicts resolves them and
+/// reports to user in `errors` field
+/// Hosts losted in `host_statistics.holoport_status` but not listed in `host_statistics.latest_raw_snap`
+/// are also marked as flawed
+pub async fn list_available_hosts(hosts: Vec<HostStats>, members: Vec<ZerotierMember>) -> Result<Vec<HostInfo>, ApiError> {
+  Ok(merge_host_info(hosts, members))
+}
+
+/// Takes each `member` and finds corresponding `host` by matching on `zerotier_ip`.
+/// Builds HostInfo based on this data and reports errors in case of inconsistency.
+/// Remaining hosts are added as HostInfo with error field set
+fn merge_host_info(
+  mut hosts: Vec<HostStats>,
+  mut members: Vec<ZerotierMember>,
+) -> Vec<HostInfo> {
+  let mut host_info_vec: Vec<HostInfo> = vec![];
+
+  // this loop iretates over all members and tries to find a matching host
+  // If it finds a matching host it removes it from hosts
+  while let Some(member) = members.pop() {
+      let mut errors: Vec<String> = vec![];
+      let host = find_in_hosts(&mut hosts, &member.zerotier_ip, &mut errors);
+      let holoport_id = resolve_holoport_id(host.holoport_id, member.name, &mut errors);
+
+      host_info_vec.push(HostInfo {
+          zerotier_ip: member.zerotier_ip,
+          wan_ip: member.physical_address,
+          last_zerotier_online: zero_to_none(member.last_online), // 0 means never seen which will print as null
+          last_netstatsd_reported: host.timestamp,
+          holoport_id,
+          registered_email: member.description,
+          holo_network: host.holo_network,
+          channel: host.channel,
+          holoport_model: host.holoport_model,
+          ssh_status: host.ssh_status,
+          hpos_app_list: host.hpos_app_list,
+          channel_version: host.channel_version,
+          hpos_version: host.hpos_version,
+          errors,
+      });
+  }
+
+  // If a host remainded in hosts then it was not present in members
+  // which means that either this zt_ip was reported also by some other holoport
+  // or that this zt_ip was not present in members at all
+  // In both cases we need to set an error
+  while let Some(host) = hosts.pop() {
+    host_info_vec.push(HostInfo {
+      zerotier_ip: host.zt_ip.clone(),
+      wan_ip: None,
+      last_zerotier_online: None,
+      last_netstatsd_reported: host.timestamp,
+      holoport_id: Some(host.holoport_id),
+      registered_email: None,
+      holo_network: host.holo_network,
+      channel: host.channel,
+      holoport_model: host.holoport_model,
+      ssh_status: host.ssh_status,
+      hpos_app_list: host.hpos_app_list,
+      channel_version: host.channel_version,
+      hpos_version: host.hpos_version,
+      errors: vec![format!("This host reported its zerotier IP as {} but Zerotier Central has no knowledge of it", host.zt_ip.unwrap_or("None".into()))],
+  });
+  }
+
+  host_info_vec
+}
+
+fn zero_to_none(num: i64) -> Option<i64> {
+  if num == 0 {
+      return None;
+  }
+  Some(num)
+}
+
+/// Finds in `hosts` a host with `zerotier_ip` and once found removes it from `hosts`. If none found returns empty `HostStats`.
+/// Sets an error in an array if `zerotier_ip` is `None`
+fn find_in_hosts(
+  hosts: &mut Vec<HostStats>,
+  zerotier_ip: &Option<String>,
+  errors: &mut Vec<String>,
+) -> HostStats {
+  if zerotier_ip.is_none() {
+      errors.push(format!(
+      "This holoport does not have IP assigned in ZT network"
+      ));
+      // Return empty HostStats
+      return HostStats::default();
+  }
+  if let Some(index) = hosts.iter().position(|host| host.zt_ip == *zerotier_ip) {
+    return hosts.swap_remove(index);
+  } else {
+    errors.push(format!(
+        "None of the holoports reporting to host_statistics.holoport_status has zerotier ip {:?}",
+        zerotier_ip
+    ));
+    HostStats::default()
+  }
+}
+
+/// Compare holoport ids reported by zerotier and netstatsd, report an error in case of mismatch
+fn resolve_holoport_id(
+  holoport_id: String,
+  zerotier_name: Option<String>,
+  errors: &mut Vec<String>,
+) -> Option<String> {
+  if zerotier_name.is_none() || Some(holoport_id.clone()) != zerotier_name {
+      errors.push(format!("Mismatched holoport ID between data from zerotier ({:?}) and netstatsd ({:?})", zerotier_name, &holoport_id));
+  }
+
+  Some(holoport_id)
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -78,7 +78,7 @@ fn zero_to_none(num: i64) -> Option<i64> {
 }
 
 /// Finds in `hosts` a host with `zerotier_ip` and once found removes it from `hosts`. If none found returns empty `HostStats`.
-/// Sets an error in an `errors` if `zerotier_ip` is `None`
+/// Sets an `errors` if `zerotier_ip` is `None`
 fn find_in_hosts(
     hosts: &mut Vec<HostStats>,
     zerotier_ip: &Option<String>,
@@ -109,6 +109,9 @@ fn resolve_holoport_id(
     zerotier_name: Option<String>,
     errors: &mut Vec<String>,
 ) -> Option<String> {
+    if holoport_id.is_empty() {
+        return None;
+    }
     if zerotier_name.is_none() || Some(holoport_id.clone()) != zerotier_name {
         errors.push(format!(
             "Mismatched holoport ID between data from zerotier ({:?}) and netstatsd ({:?})",

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -63,7 +63,7 @@ fn merge_host_info(mut hosts: Vec<HostStats>, mut members: Vec<ZerotierMember>) 
             hpos_app_list: host.hpos_app_list,
             channel_version: host.channel_version,
             hpos_version: host.hpos_version,
-            errors: vec![format!("This host reported its zerotier IP as {} but Zerotier Central has no knowledge of it", host.zt_ip.unwrap_or("None".into()))],
+            errors: vec![format!("Netstatsd reported zerotier IP as {} but Zerotier Central has no knowledge of it", host.zt_ip.unwrap_or("None".into()))],
         });
     }
 
@@ -95,8 +95,8 @@ fn find_in_hosts(
         return hosts.swap_remove(index);
     } else {
         errors.push(format!(
-        "None of the holoports reporting to host_statistics.holoport_status has zerotier ip {:?}",
-        zerotier_ip
+        "IP {} is listed on Zerotier as active, but none fo the holoports reports that way via netstatsd",
+        zerotier_ip.as_ref().unwrap_or(&"???".to_string())
     ));
         HostStats::default()
     }
@@ -114,8 +114,8 @@ fn resolve_holoport_id(
     }
     if zerotier_name.is_none() || Some(holoport_id.clone()) != zerotier_name {
         errors.push(format!(
-            "Mismatched holoport ID between data from zerotier ({:?}) and netstatsd ({:?})",
-            zerotier_name, &holoport_id
+            "Mismatched holoport ID between data from zerotier ({}) and netstatsd ({})",
+            zerotier_name.unwrap_or("???".into()), &holoport_id
         ));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ use rocket::*;
 use rocket::{self, get, post, State};
 
 mod db;
-mod types;
 mod handlers;
+mod types;
 
 use handlers::list_available_hosts;
 use types::{ApiError, Capacity, HostInfo, HostStats, Result, Uptime};

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,11 @@ async fn index(pool: &State<db::AppDbPool>) -> Result<String> {
     db::ping_database(&pool.mongo).await
 }
 
+#[delete("/cleanup")]
+async fn cleanup(pool: &State<db::AppDbPool>) -> Result<String, ApiError> {
+    db::cleanup_database(&pool.mongo).await
+}
+
 #[get("/<name>/uptime")]
 async fn uptime(name: String, pool: &State<db::AppDbPool>) -> Result<Option<Json<Uptime>>> {
     if let Some(uptime) = db::host_uptime(name, &pool.mongo).await {
@@ -51,7 +56,7 @@ async fn add_host_stats(stats: HostStats, pool: &State<db::AppDbPool>) -> Result
 async fn rocket() -> _ {
     rocket::build()
         .manage(db::init_db_pool().await)
-        .mount("/", rocket::routes![index])
+        .mount("/", rocket::routes![index, cleanup])
         .mount(
             "/hosts/",
             rocket::routes![uptime, list_available, add_host_stats],

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn capacity(pool: &State<db::AppDbPool>) -> Result<Json<Capacity>> {
 
 #[post("/stats", format = "application/json", data = "<stats>")]
 async fn add_host_stats(stats: HostStats, pool: &State<db::AppDbPool>) -> Result<(), ApiError> {
-    Ok(db::add_host_stats(stats, &pool).await?)
+    db::add_host_stats(stats, pool).await
 }
 
 #[launch]

--- a/src/old_integration_test.rs
+++ b/src/old_integration_test.rs
@@ -1,0 +1,271 @@
+#![allow(deprecated)]
+
+use super::rocket;
+use anyhow::{Context, Result};
+use base64::encode_config;
+use ed25519_dalek::*;
+use holochain_conductor_api::{AppStatusFilter, InstalledAppInfo, InstalledAppInfoStatus};
+use holochain_types::{
+    app::{DisabledAppReason, PausedAppReason},
+    dna::{AgentPubKey, DnaHash},
+    prelude::{CellId, InstalledCell},
+};
+use mongodb::bson::{doc, oid::ObjectId, Document};
+use mongodb::Collection;
+use rocket::http::ContentType;
+use rocket::http::Header;
+use rocket::http::Status;
+use rocket::local::asynchronous::Client;
+use rocket::response::Debug;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::env::var;
+use test_case::test_case;
+
+use crate::types;
+use types::{
+    AgentPubKeys, ApiError, DateCreated, HostRegistration, HostStats, NumberInt, NumberLong,
+    OldHoloportIds, RegistrationCode,
+};
+
+async fn sign_payload(payload: &HostStats) -> Result<String> {
+    let keypair =
+    hpos_config_seed_bundle_explorer::unlock(&"k6VoY3NiMJGWonB3xBAAQN7Er6j8qToC9DmZLEuyzSAAAcQYio6xDNOQk3OUasqcEakpoYHPrJRGTduhxDFlOTHqQ5KPP4kYlSbq7xFRswXhPAfnfzI-JcAgkHwosIgqf0tYSCCzI8U0JOhNRLxJxCyCrWRldmljZV9udW1iZXIAq2dlbmVyYXRlX2J5r3F1aWNrc3RhcnQtdjIuMA".to_string(), Some("pass".to_string()))
+        .await
+        .context(format!("Unable to unlock the device bundle"))?;
+    let payload = serde_json::to_vec(&payload).context("Failed to convert payload to bytes")?;
+    let signature = keypair
+        .try_sign(&payload)
+        .context("Failed to sign payload")?;
+    Ok(encode_config(
+        &signature.to_bytes()[..],
+        base64::STANDARD_NO_PAD,
+    ))
+}
+
+// Add values to the collection `registrations`
+async fn add_host_registration(
+    hr: HostRegistration,
+    local_db: &mongodb::Client,
+) -> Result<(), ApiError> {
+    let hp_status: Collection<Document> = local_db
+        .database("opsconsoledb")
+        .collection("registrations");
+    let agent_pub_keys_doc = doc! {
+        "pub_key": &hr.registration_code[0].agent_pub_keys[0].pub_key,
+        "role": &hr.registration_code[0].agent_pub_keys[0].role,
+    };
+
+    let registration_code_doc = doc! {
+        "code": &hr.registration_code[0].code,
+        "role": &hr.registration_code[0].role,
+        "agent_pub_keys": agent_pub_keys_doc
+    };
+
+    let number_long_doc = doc! {
+        "number_long": hr.created.date.number_long.to_string()
+    };
+
+    let date_created_doc = doc! {
+        "date": number_long_doc
+    };
+
+    let number_int_doc = doc! {
+        "number_int": hr.__v.number_int.to_string()
+    };
+
+    let old_holoport_ids_doc = doc! {
+        "_id": &hr.old_holoport_ids[0]._id,
+        "processed": &hr.old_holoport_ids[0].processed,
+        "newId": &hr.old_holoport_ids[0].new_id
+    };
+
+    let val = doc! {
+        "_id" : hr._id,
+        "givenNames" : hr.given_names,
+        "lastName" : hr.last_name,
+        "email" : hr.email,
+        "isJurisdictionNotInList" : hr.is_jurisdiction_not_in_list,
+        "legalJurisdiction" : hr.legal_jurisdiction,
+        "created" : date_created_doc,
+        "oldHoloportIds" : old_holoport_ids_doc,
+        "registrationCode" : registration_code_doc,
+        "__v" : number_int_doc
+    };
+    match hp_status.insert_one(val.clone(), None).await {
+        Ok(_) => Ok(()),
+        Err(e) => Err(ApiError::Database(Debug(e))),
+    }
+}
+
+fn gen_mock_apps(
+    running_count: i32,
+    paused_count: i32,
+    disabled_count: i32,
+) -> Vec<InstalledAppInfo> {
+    let mut hpos_apps = Vec::new();
+
+    let mut add_app = |number: i32, status: InstalledAppInfoStatus| {
+        hpos_apps.push(InstalledAppInfo {
+            installed_app_id: format!("uhCkk...appId{:?}-{:?}", number, status),
+            cell_data: vec![InstalledCell::new(
+                CellId::new(
+                    DnaHash::try_from("uhC0k8AVWbDh5OJG6WYOK9SkkNx4qCO9AVEmQSSimyO3-oi7BnXil")
+                        .unwrap(),
+                    AgentPubKey::try_from("uhCAkOyRlY09kreaeLDd9-0bp-17DW2N4Vqx1kFodKTXFkrgFiA09")
+                        .unwrap(),
+                ),
+                format!("app_role_id_{:?}-{:?}", number, status),
+            )],
+            status: status,
+        })
+    };
+
+    for i in 0..running_count {
+        add_app(i, InstalledAppInfoStatus::Running)
+    }
+
+    for i in 0..paused_count {
+        add_app(
+            i,
+            InstalledAppInfoStatus::Paused {
+                reason: PausedAppReason::Error("Paused Error Reason".to_string()),
+            },
+        )
+    }
+
+    for i in 0..disabled_count {
+        add_app(
+            i,
+            InstalledAppInfoStatus::Disabled {
+                reason: DisabledAppReason::Error("Disabled Error Reason".to_string()),
+            },
+        )
+    }
+
+    hpos_apps
+}
+
+#[rocket::async_test]
+async fn call_index() {
+    let client = Client::tracked(super::rocket().await)
+        .await
+        .expect("valid rocket instance");
+    let response = client.get("/").dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(
+        response.into_string().await.unwrap(),
+        "Connected to db. v0.0.2"
+    );
+}
+
+#[test_case(true ; "when signature is valid")]
+#[test_case(false  ; "when signature is not valid")]
+#[rocket::async_test]
+async fn add_host_stats(pass_valid_signature: bool) {
+    let mongo_uri: String = var("MONGO_URI").expect("MONGO_URI must be set in the env");
+    let client = mongodb::Client::with_uri_str(mongo_uri).await.unwrap();
+
+    // Pre-populate `opsconsoledb` registrations collection with host that has a `pub_key` matching the `holoport_id` sent in `/host/stats` post payload
+    let host_registration = HostRegistration {
+        _id: ObjectId::new(),
+        given_names: "FirstName".to_string(),
+        last_name: "LastName".to_string(),
+        email: "first.last1@email.com".to_string(),
+        is_jurisdiction_not_in_list: true,
+        legal_jurisdiction: "United States".to_string(),
+        created: DateCreated {
+            date: NumberLong {
+                number_long: 1646149410
+            }
+        },
+        old_holoport_ids: vec![OldHoloportIds {
+            _id: "0waaoeca1p8hcwmxpfupp6lr0ydy495qj9eoas1tq6qnblzpn".to_string(),
+            processed: true,
+            new_id: "52khmj02jl1xkl5mo6v0hoa4p2gftv33plgt69ay5i3ebjtu6k".to_string(),
+        }],
+        registration_code : vec![
+            RegistrationCode {
+                code : "Cv/aKR0JreZaeY0ioDoEDiSg78GiYwtZJYDmeLq6C7qN9p39kqu9RV8aSB8pzdVGiU/2STXfWZJC8kj3H2G4HA==".to_string(),
+                role : "host".to_string(),
+                agent_pub_keys : vec![
+                    AgentPubKeys {
+                        role : "host".to_string(),
+                        // Note: The `pub_key` must be the holo_hash encoded version of the host's `holoport_id`
+                        pub_key : "uhCAkOyRlY09kreaeLDd9-0bp-17DW2N4Vqx1kFodKTXFkrgFiA09".to_string()
+                    }
+                ]
+            }
+        ],
+        __v: NumberInt {
+            number_int: 16410
+        },
+    };
+
+    let _ = add_host_registration(host_registration, &client).await;
+
+    let mut paused_count = 0;
+    let mut running_count = 0;
+    let mut disabled_count = 0;
+
+    let mut hpos_app_list = HashMap::new();
+    let hpos_happs_mock = gen_mock_apps(3, 2, 1);
+
+    hpos_happs_mock.iter().for_each(|happ| {
+        let happ_status = match &happ.status {
+            InstalledAppInfoStatus::Paused { .. } => {
+                paused_count += 1;
+                AppStatusFilter::Paused
+            }
+            InstalledAppInfoStatus::Disabled { .. } => {
+                disabled_count += 1;
+                AppStatusFilter::Disabled
+            }
+            InstalledAppInfoStatus::Running => {
+                running_count += 1;
+                AppStatusFilter::Running
+            }
+        };
+        hpos_app_list.insert(happ.installed_app_id.clone(), happ_status);
+    });
+
+    // Test hpos_app_list count and status:
+    assert_eq!(hpos_app_list.len(), 6);
+    assert_eq!(disabled_count, 1);
+    assert_eq!(paused_count, 2);
+    assert_eq!(running_count, 3);
+
+    // Create payload, sign payload, and call `/host/stats` endpoint, passing valid signature within call header
+    let payload = HostStats {
+        // Note: The `holoport_id` must be the base_36 encoded version of the `host_registration.registration_code[i].agent_pub_keys[i].pub_key`
+        holoport_id: "1h2di6px7otkjwudmycadu5teaywao46jelpegg7jujncbcbzs".to_string(),
+        hpos_app_list: Some(hpos_app_list),
+        ..Default::default()
+    };
+
+    let signature;
+    let status;
+    if pass_valid_signature {
+        signature = sign_payload(&payload).await.unwrap();
+        status = Status::Ok;
+    } else {
+        // Provide a valid signature signed with incorrect keys to test unauth'd case
+        signature =
+            "oAcrxO0Xn2/Rub7BsNLgYRE1Km8Hn/+eWeYf2hpFziQ3qRRzwOEdEm+L9UvZK6FDLJf//BNPQrrTAZW0X6doAw"
+                .to_string();
+        status = Status::Unauthorized;
+    }
+
+    let client = Client::tracked(super::rocket().await)
+        .await
+        .expect("valid rocket instance");
+    let response = client
+        .post("/hosts/stats")
+        .json(&payload)
+        .header(ContentType::JSON)
+        .header(Header::new("x-hpos-signature", signature))
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), status);
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -32,24 +32,22 @@ async fn host_found_with_no_errors() {
         description: Some("beno@email.qq".into()),
     });
 
-    let expected_result = vec![
-        HostInfo {
-            zerotier_ip: Some("172.26.215.30".into()),
-            wan_ip: Some("8.12.11.123".into()),
-            last_zerotier_online: Some(123456678899),
-            last_netstatsd_reported: Some(12345678910),
-            holoport_id: Some("5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4".into()),
-            registered_email: Some("beno@email.qq".into()),
-            holo_network: Some("mainNet".into()),
-            channel: Some("master".into()),
-            holoport_model: Some("holoportPlus".into()),
-            ssh_status: Some(true),
-            hpos_app_list: Some(HashMap::new()),
-            channel_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7cc1e18dd".into()),
-            hpos_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7cc1e18dd".into()),
-            errors: vec![],
-        },
-    ];
+    let expected_result = vec![HostInfo {
+        zerotier_ip: Some("172.26.215.30".into()),
+        wan_ip: Some("8.12.11.123".into()),
+        last_zerotier_online: Some(123456678899),
+        last_netstatsd_reported: Some(12345678910),
+        holoport_id: Some("5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4".into()),
+        registered_email: Some("beno@email.qq".into()),
+        holo_network: Some("mainNet".into()),
+        channel: Some("master".into()),
+        holoport_model: Some("holoportPlus".into()),
+        ssh_status: Some(true),
+        hpos_app_list: Some(HashMap::new()),
+        channel_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7cc1e18dd".into()),
+        hpos_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7cc1e18dd".into()),
+        errors: vec![],
+    }];
 
     let result = list_available_hosts(hosts, members).await.unwrap();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -133,7 +133,7 @@ async fn host_not_found() {
             channel_version: None,
             hpos_version: None,
             errors: vec![
-              "IP 172.26.215.31 is listed on Zerotier as active, but none fo the holoports reports that way via netstatsd".to_string()
+              "IP 172.26.215.31 is listed in Zerotier Central as active, but no holoport reported this IP via netstatsd within queried timeframe".to_string()
             ],
         },
     ];

--- a/src/test.rs
+++ b/src/test.rs
@@ -95,7 +95,7 @@ async fn host_found_mismatched_names() {
             hpos_app_list: Some(HashMap::new()),
             channel_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaaa".into()),
             hpos_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaab".into()),
-            errors: vec!["Mismatched holoport ID between data from zerotier (Some(\"5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4\")) and netstatsd (\"6avezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy58g4iy5\")".into()],
+            errors: vec!["Mismatched holoport ID between data from zerotier (5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4) and netstatsd (6avezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy58g4iy5)".into()],
         },
     ];
 
@@ -133,7 +133,7 @@ async fn host_not_found() {
             channel_version: None,
             hpos_version: None,
             errors: vec![
-              "None of the holoports reporting to host_statistics.holoport_status has zerotier ip Some(\"172.26.215.31\")".to_string()
+              "IP 172.26.215.31 is listed on Zerotier as active, but none fo the holoports reports that way via netstatsd".to_string()
             ],
         },
     ];
@@ -177,7 +177,7 @@ async fn zt_member_not_found() {
             hpos_app_list: Some(HashMap::new()),
             channel_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaaa".into()),
             hpos_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaab".into()),
-            errors: vec!["This host reported its zerotier IP as 172.26.215.31 but Zerotier Central has no knowledge of it".into()],
+            errors: vec!["Netstatsd reported zerotier IP as 172.26.215.31 but Zerotier Central has no knowledge of it".into()],
         },
     ];
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -103,3 +103,85 @@ async fn host_found_mismatched_names() {
 
     assert_eq!(&expected_result[..], &result[..]);
 }
+
+#[rocket::async_test]
+async fn host_not_found() {
+    let hosts: Vec<HostStats> = vec![];
+
+    let mut members: Vec<ZerotierMember> = vec![];
+    members.push(ZerotierMember {
+        last_online: 123456678810,
+        zerotier_ip: Some("172.26.215.31".into()),
+        physical_address: Some("77.12.0.3".into()),
+        name: Some("5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4".into()),
+        description: Some("alex@email.qq".into()),
+    });
+
+    let expected_result = vec![
+        HostInfo {
+            zerotier_ip: Some("172.26.215.31".into()),
+            wan_ip: Some("77.12.0.3".into()),
+            last_zerotier_online: Some(123456678810),
+            last_netstatsd_reported: None,
+            holoport_id: None,
+            registered_email: Some("alex@email.qq".into()),
+            holo_network: None,
+            channel: None,
+            holoport_model: None,
+            ssh_status: None,
+            hpos_app_list: None,
+            channel_version: None,
+            hpos_version: None,
+            errors: vec![
+              "None of the holoports reporting to host_statistics.holoport_status has zerotier ip Some(\"172.26.215.31\")".to_string()
+            ],
+        },
+    ];
+
+    let result = list_available_hosts(hosts, members).await.unwrap();
+
+    assert_eq!(&expected_result[..], &result[..]);
+}
+
+#[rocket::async_test]
+async fn zt_member_not_found() {
+    let mut hosts: Vec<HostStats> = vec![];
+    hosts.push(HostStats {
+        holo_network: Some("devNet".into()),
+        channel: Some("develop".into()),
+        holoport_model: Some("holoport".into()),
+        ssh_status: Some(false),
+        zt_ip: Some("172.26.215.31".into()),
+        wan_ip: Some("77.12.0.3".into()),
+        holoport_id: "6avezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy58g4iy5".into(),
+        timestamp: Some(12345678000),
+        hpos_app_list: Some(HashMap::new()),
+        channel_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaaa".into()),
+        hpos_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaab".into()),
+    });
+
+    let members: Vec<ZerotierMember> = vec![];
+
+    let expected_result = vec![
+        HostInfo {
+            zerotier_ip: Some("172.26.215.31".into()),
+            wan_ip: None,
+            last_zerotier_online: None,
+            last_netstatsd_reported: Some(12345678000),
+            holoport_id: Some("6avezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy58g4iy5".into()),
+            registered_email: None,
+            holo_network: Some("devNet".into()),
+            channel: Some("develop".into()),
+            holoport_model: Some("holoport".into()),
+            ssh_status: Some(false),
+            hpos_app_list: Some(HashMap::new()),
+            channel_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaaa".into()),
+            hpos_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaab".into()),
+            errors: vec!["This host reported its zerotier IP as 172.26.215.31 but Zerotier Central has no knowledge of it".into()],
+        },
+    ];
+
+    let result = list_available_hosts(hosts, members).await.unwrap();
+
+    assert_eq!(&expected_result[..], &result[..]);
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,271 +1,107 @@
-#![allow(deprecated)]
-
-use super::rocket;
-use anyhow::{Context, Result};
-use base64::encode_config;
-use ed25519_dalek::*;
-use holochain_conductor_api::{AppStatusFilter, InstalledAppInfo, InstalledAppInfoStatus};
-use holochain_types::{
-    app::{DisabledAppReason, PausedAppReason},
-    dna::{AgentPubKey, DnaHash},
-    prelude::{CellId, InstalledCell},
-};
-use mongodb::bson::{doc, oid::ObjectId, Document};
-use mongodb::Collection;
-use rocket::http::ContentType;
-use rocket::http::Header;
-use rocket::http::Status;
-use rocket::local::asynchronous::Client;
-use rocket::response::Debug;
 use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::env::var;
-use test_case::test_case;
 
-use crate::types;
-use types::{
-    AgentPubKeys, ApiError, DateCreated, HostRegistration, HostStats, NumberInt, NumberLong,
-    OldHoloportIds, RegistrationCode,
-};
-
-async fn sign_payload(payload: &HostStats) -> Result<String> {
-    let keypair =
-    hpos_config_seed_bundle_explorer::unlock(&"k6VoY3NiMJGWonB3xBAAQN7Er6j8qToC9DmZLEuyzSAAAcQYio6xDNOQk3OUasqcEakpoYHPrJRGTduhxDFlOTHqQ5KPP4kYlSbq7xFRswXhPAfnfzI-JcAgkHwosIgqf0tYSCCzI8U0JOhNRLxJxCyCrWRldmljZV9udW1iZXIAq2dlbmVyYXRlX2J5r3F1aWNrc3RhcnQtdjIuMA".to_string(), Some("pass".to_string()))
-        .await
-        .context(format!("Unable to unlock the device bundle"))?;
-    let payload = serde_json::to_vec(&payload).context("Failed to convert payload to bytes")?;
-    let signature = keypair
-        .try_sign(&payload)
-        .context("Failed to sign payload")?;
-    Ok(encode_config(
-        &signature.to_bytes()[..],
-        base64::STANDARD_NO_PAD,
-    ))
-}
-
-// Add values to the collection `registrations`
-async fn add_host_registration(
-    hr: HostRegistration,
-    local_db: &mongodb::Client,
-) -> Result<(), ApiError> {
-    let hp_status: Collection<Document> = local_db
-        .database("opsconsoledb")
-        .collection("registrations");
-    let agent_pub_keys_doc = doc! {
-        "pub_key": &hr.registration_code[0].agent_pub_keys[0].pub_key,
-        "role": &hr.registration_code[0].agent_pub_keys[0].role,
-    };
-
-    let registration_code_doc = doc! {
-        "code": &hr.registration_code[0].code,
-        "role": &hr.registration_code[0].role,
-        "agent_pub_keys": agent_pub_keys_doc
-    };
-
-    let number_long_doc = doc! {
-        "number_long": hr.created.date.number_long.to_string()
-    };
-
-    let date_created_doc = doc! {
-        "date": number_long_doc
-    };
-
-    let number_int_doc = doc! {
-        "number_int": hr.__v.number_int.to_string()
-    };
-
-    let old_holoport_ids_doc = doc! {
-        "_id": &hr.old_holoport_ids[0]._id,
-        "processed": &hr.old_holoport_ids[0].processed,
-        "newId": &hr.old_holoport_ids[0].new_id
-    };
-
-    let val = doc! {
-        "_id" : hr._id,
-        "givenNames" : hr.given_names,
-        "lastName" : hr.last_name,
-        "email" : hr.email,
-        "isJurisdictionNotInList" : hr.is_jurisdiction_not_in_list,
-        "legalJurisdiction" : hr.legal_jurisdiction,
-        "created" : date_created_doc,
-        "oldHoloportIds" : old_holoport_ids_doc,
-        "registrationCode" : registration_code_doc,
-        "__v" : number_int_doc
-    };
-    match hp_status.insert_one(val.clone(), None).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(ApiError::Database(Debug(e))),
-    }
-}
-
-fn gen_mock_apps(
-    running_count: i32,
-    paused_count: i32,
-    disabled_count: i32,
-) -> Vec<InstalledAppInfo> {
-    let mut hpos_apps = Vec::new();
-
-    let mut add_app = |number: i32, status: InstalledAppInfoStatus| {
-        hpos_apps.push(InstalledAppInfo {
-            installed_app_id: format!("uhCkk...appId{:?}-{:?}", number, status),
-            cell_data: vec![InstalledCell::new(
-                CellId::new(
-                    DnaHash::try_from("uhC0k8AVWbDh5OJG6WYOK9SkkNx4qCO9AVEmQSSimyO3-oi7BnXil")
-                        .unwrap(),
-                    AgentPubKey::try_from("uhCAkOyRlY09kreaeLDd9-0bp-17DW2N4Vqx1kFodKTXFkrgFiA09")
-                        .unwrap(),
-                ),
-                format!("app_role_id_{:?}-{:?}", number, status),
-            )],
-            status: status,
-        })
-    };
-
-    for i in 0..running_count {
-        add_app(i, InstalledAppInfoStatus::Running)
-    }
-
-    for i in 0..paused_count {
-        add_app(
-            i,
-            InstalledAppInfoStatus::Paused {
-                reason: PausedAppReason::Error("Paused Error Reason".to_string()),
-            },
-        )
-    }
-
-    for i in 0..disabled_count {
-        add_app(
-            i,
-            InstalledAppInfoStatus::Disabled {
-                reason: DisabledAppReason::Error("Disabled Error Reason".to_string()),
-            },
-        )
-    }
-
-    hpos_apps
-}
+/// Unit tests of handler functions
+/// All those tests that require interaction with db are included
+/// in integration test suite
+use super::handlers::list_available_hosts;
+use super::types::{HostInfo, HostStats, ZerotierMember};
 
 #[rocket::async_test]
-async fn call_index() {
-    let client = Client::tracked(super::rocket().await)
-        .await
-        .expect("valid rocket instance");
-    let response = client.get("/").dispatch().await;
-    assert_eq!(response.status(), Status::Ok);
-    assert_eq!(
-        response.into_string().await.unwrap(),
-        "Connected to db. v0.0.2"
-    );
-}
-
-#[test_case(true ; "when signature is valid")]
-#[test_case(false  ; "when signature is not valid")]
-#[rocket::async_test]
-async fn add_host_stats(pass_valid_signature: bool) {
-    let mongo_uri: String = var("MONGO_URI").expect("MONGO_URI must be set in the env");
-    let client = mongodb::Client::with_uri_str(mongo_uri).await.unwrap();
-
-    // Pre-populate `opsconsoledb` registrations collection with host that has a `pub_key` matching the `holoport_id` sent in `/host/stats` post payload
-    let host_registration = HostRegistration {
-        _id: ObjectId::new(),
-        given_names: "FirstName".to_string(),
-        last_name: "LastName".to_string(),
-        email: "first.last1@email.com".to_string(),
-        is_jurisdiction_not_in_list: true,
-        legal_jurisdiction: "United States".to_string(),
-        created: DateCreated {
-            date: NumberLong {
-                number_long: 1646149410
-            }
-        },
-        old_holoport_ids: vec![OldHoloportIds {
-            _id: "0waaoeca1p8hcwmxpfupp6lr0ydy495qj9eoas1tq6qnblzpn".to_string(),
-            processed: true,
-            new_id: "52khmj02jl1xkl5mo6v0hoa4p2gftv33plgt69ay5i3ebjtu6k".to_string(),
-        }],
-        registration_code : vec![
-            RegistrationCode {
-                code : "Cv/aKR0JreZaeY0ioDoEDiSg78GiYwtZJYDmeLq6C7qN9p39kqu9RV8aSB8pzdVGiU/2STXfWZJC8kj3H2G4HA==".to_string(),
-                role : "host".to_string(),
-                agent_pub_keys : vec![
-                    AgentPubKeys {
-                        role : "host".to_string(),
-                        // Note: The `pub_key` must be the holo_hash encoded version of the host's `holoport_id`
-                        pub_key : "uhCAkOyRlY09kreaeLDd9-0bp-17DW2N4Vqx1kFodKTXFkrgFiA09".to_string()
-                    }
-                ]
-            }
-        ],
-        __v: NumberInt {
-            number_int: 16410
-        },
-    };
-
-    let _ = add_host_registration(host_registration, &client).await;
-
-    let mut paused_count = 0;
-    let mut running_count = 0;
-    let mut disabled_count = 0;
-
-    let mut hpos_app_list = HashMap::new();
-    let hpos_happs_mock = gen_mock_apps(3, 2, 1);
-
-    hpos_happs_mock.iter().for_each(|happ| {
-        let happ_status = match &happ.status {
-            InstalledAppInfoStatus::Paused { .. } => {
-                paused_count += 1;
-                AppStatusFilter::Paused
-            }
-            InstalledAppInfoStatus::Disabled { .. } => {
-                disabled_count += 1;
-                AppStatusFilter::Disabled
-            }
-            InstalledAppInfoStatus::Running => {
-                running_count += 1;
-                AppStatusFilter::Running
-            }
-        };
-        hpos_app_list.insert(happ.installed_app_id.clone(), happ_status);
+async fn host_found_with_no_errors() {
+    let mut hosts: Vec<HostStats> = vec![];
+    hosts.push(HostStats {
+        holo_network: Some("mainNet".into()),
+        channel: Some("master".into()),
+        holoport_model: Some("holoportPlus".into()),
+        ssh_status: Some(true),
+        zt_ip: Some("172.26.215.30".into()),
+        wan_ip: Some("8.12.11.123".into()),
+        holoport_id: "5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4".into(),
+        timestamp: Some(12345678910),
+        hpos_app_list: Some(HashMap::new()),
+        channel_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7cc1e18dd".into()),
+        hpos_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7cc1e18dd".into()),
     });
 
-    // Test hpos_app_list count and status:
-    assert_eq!(hpos_app_list.len(), 6);
-    assert_eq!(disabled_count, 1);
-    assert_eq!(paused_count, 2);
-    assert_eq!(running_count, 3);
+    let mut members: Vec<ZerotierMember> = vec![];
+    members.push(ZerotierMember {
+        last_online: 123456678899,
+        zerotier_ip: Some("172.26.215.30".into()),
+        physical_address: Some("8.12.11.123".into()),
+        name: Some("5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4".into()),
+        description: Some("beno@email.qq".into()),
+    });
 
-    // Create payload, sign payload, and call `/host/stats` endpoint, passing valid signature within call header
-    let payload = HostStats {
-        // Note: The `holoport_id` must be the base_36 encoded version of the `host_registration.registration_code[i].agent_pub_keys[i].pub_key`
-        holoport_id: "1h2di6px7otkjwudmycadu5teaywao46jelpegg7jujncbcbzs".to_string(),
-        hpos_app_list: Some(hpos_app_list),
-        ..Default::default()
-    };
+    let expected_result = vec![
+        HostInfo {
+            zerotier_ip: Some("172.26.215.30".into()),
+            wan_ip: Some("8.12.11.123".into()),
+            last_zerotier_online: Some(123456678899),
+            last_netstatsd_reported: Some(12345678910),
+            holoport_id: Some("5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4".into()),
+            registered_email: Some("beno@email.qq".into()),
+            holo_network: Some("mainNet".into()),
+            channel: Some("master".into()),
+            holoport_model: Some("holoportPlus".into()),
+            ssh_status: Some(true),
+            hpos_app_list: Some(HashMap::new()),
+            channel_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7cc1e18dd".into()),
+            hpos_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7cc1e18dd".into()),
+            errors: vec![],
+        },
+    ];
 
-    let signature;
-    let status;
-    if pass_valid_signature {
-        signature = sign_payload(&payload).await.unwrap();
-        status = Status::Ok;
-    } else {
-        // Provide a valid signature signed with incorrect keys to test unauth'd case
-        signature =
-            "oAcrxO0Xn2/Rub7BsNLgYRE1Km8Hn/+eWeYf2hpFziQ3qRRzwOEdEm+L9UvZK6FDLJf//BNPQrrTAZW0X6doAw"
-                .to_string();
-        status = Status::Unauthorized;
-    }
+    let result = list_available_hosts(hosts, members).await.unwrap();
 
-    let client = Client::tracked(super::rocket().await)
-        .await
-        .expect("valid rocket instance");
-    let response = client
-        .post("/hosts/stats")
-        .json(&payload)
-        .header(ContentType::JSON)
-        .header(Header::new("x-hpos-signature", signature))
-        .dispatch()
-        .await;
+    assert_eq!(&expected_result[..], &result[..]);
+}
 
-    assert_eq!(response.status(), status);
+#[rocket::async_test]
+async fn host_found_mismatched_names() {
+    let mut hosts: Vec<HostStats> = vec![];
+    hosts.push(HostStats {
+        holo_network: Some("devNet".into()),
+        channel: Some("develop".into()),
+        holoport_model: Some("holoport".into()),
+        ssh_status: Some(false),
+        zt_ip: Some("172.26.215.31".into()),
+        wan_ip: Some("77.12.0.3".into()),
+        holoport_id: "6avezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy58g4iy5".into(),
+        timestamp: Some(12345678000),
+        hpos_app_list: Some(HashMap::new()),
+        channel_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaaa".into()),
+        hpos_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaab".into()),
+    });
+
+    let mut members: Vec<ZerotierMember> = vec![];
+    members.push(ZerotierMember {
+        last_online: 123456678810,
+        zerotier_ip: Some("172.26.215.31".into()),
+        physical_address: Some("77.12.0.3".into()),
+        name: Some("5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4".into()),
+        description: Some("alex@email.qq".into()),
+    });
+
+    let expected_result = vec![
+        HostInfo {
+            zerotier_ip: Some("172.26.215.31".into()),
+            wan_ip: Some("77.12.0.3".into()),
+            last_zerotier_online: Some(123456678810),
+            last_netstatsd_reported: Some(12345678000),
+            holoport_id: Some("6avezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy58g4iy5".into()),
+            registered_email: Some("alex@email.qq".into()),
+            holo_network: Some("devNet".into()),
+            channel: Some("develop".into()),
+            holoport_model: Some("holoport".into()),
+            ssh_status: Some(false),
+            hpos_app_list: Some(HashMap::new()),
+            channel_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaaa".into()),
+            hpos_version: Some("89ec8aaef697b4741e6f0cefc4a9f8e7aaaaaab".into()),
+            errors: vec!["Mismatched holoport ID between data from zerotier (Some(\"5zvezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy5ite9a4\")) and netstatsd (\"6avezgwyz5robqc9s20n9655be0ot9vxmgqwm8g4iy58g4iy5\")".into()],
+        },
+    ];
+
+    let result = list_available_hosts(hosts, members).await.unwrap();
+
+    assert_eq!(&expected_result[..], &result[..]);
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -110,7 +110,7 @@ pub struct Assignment {
 }
 
 // Return type for /list-available endpoint
-#[derive(Serialize, Deserialize, Debug, Eq)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct HostInfo {

--- a/src/types.rs
+++ b/src/types.rs
@@ -149,15 +149,26 @@ impl PartialEq for HostInfo {
     }
 }
 
+/// Checks if two HashMaps<InstalledAppId, AppStatusFilter> are
+/// equal. This check is perpormed only for keys, because values are of a type
+/// AppStatusFilter which does not implement Partial_eq nor Eq trait, which makes it
+/// impossible to compare values. Buuuuu.
 fn is_hashmap_equal(
     first: &Option<HashMap<InstalledAppId, AppStatusFilter>>,
     second: &Option<HashMap<InstalledAppId, AppStatusFilter>>,
 ) -> bool {
     match (first, second) {
         (None, None) => true,
-        (Some(first_map), Some(second_map)) => true,
+        (Some(first_map), Some(second_map)) => keys_match(first_map, second_map),
         _ => false,
     }
+}
+
+fn keys_match(
+    map1: &HashMap<InstalledAppId, AppStatusFilter>,
+    map2: &HashMap<InstalledAppId, AppStatusFilter>,
+) -> bool {
+    map1.len() == map2.len() && map1.keys().all(|k| map2.contains_key(k))
 }
 
 // Input type for /hosts/stats endpoint

--- a/src/types.rs
+++ b/src/types.rs
@@ -109,8 +109,29 @@ pub struct Assignment {
     pub name: String,
 }
 
+// Return type for /list-available endpoint
+#[derive(Serialize, Deserialize)]
+#[serde(crate = "rocket::serde")]
+#[serde(rename_all = "camelCase")]
+pub struct HostInfo {
+    pub zerotier_ip: Option<String>,
+    pub wan_ip: Option<String>,
+    pub last_zerotier_online: Option<i64>,
+    pub last_netstatsd_reported: Option<i64>,
+    pub holoport_id: Option<String>,
+    pub registered_email: Option<String>,
+    pub holo_network: Option<String>,
+    pub channel: Option<String>,
+    pub holoport_model: Option<String>,
+    pub ssh_status: Option<bool>,
+    pub hpos_app_list: Option<HashMap<InstalledAppId, AppStatusFilter>>,
+    pub channel_version: Option<String>,
+    pub hpos_version: Option<String>,
+    pub errors: Vec<String>,
+}
+
 // Input type for /hosts/stats endpoint
-// Data schema in collection `holoport_status`
+// Data schema in collection `host_statistics.holoport_status`
 // Note: We wrap each field value in Option<T> because if the HPOS `netstatd` fails to collect data, it will send null in failed field.
 #[derive(Serialize, Deserialize, Clone, Default)]
 #[serde(crate = "rocket::serde")]
@@ -194,6 +215,19 @@ impl<'r> FromData<'r> for HostStats {
             )),
         ))
     }
+}
+
+// Data schema of records retrieved from collection `host_statistics.latest_raw_snap`
+// Note - we are collecting only a subset of oryginal fields
+#[derive(Serialize, Deserialize, Clone, Default)]
+#[serde(crate = "rocket::serde")]
+#[serde(rename_all = "camelCase")]
+pub struct ZerotierMember {
+    pub last_online: i64,
+    pub zerotier_ip: Option<String>,
+    pub physical_address: Option<String>,
+    pub name: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,3 @@
-use base64;
 use ed25519_dalek::Signature;
 use rocket::data::{self, Data, FromData};
 use rocket::http::{Method, Status};

--- a/src/types.rs
+++ b/src/types.rs
@@ -110,7 +110,7 @@ pub struct Assignment {
 }
 
 // Return type for /list-available endpoint
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Eq)]
 #[serde(crate = "rocket::serde")]
 #[serde(rename_all = "camelCase")]
 pub struct HostInfo {
@@ -128,6 +128,36 @@ pub struct HostInfo {
     pub channel_version: Option<String>,
     pub hpos_version: Option<String>,
     pub errors: Vec<String>,
+}
+
+impl PartialEq for HostInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.zerotier_ip == other.zerotier_ip
+            && self.wan_ip == other.wan_ip
+            && self.last_zerotier_online == other.last_zerotier_online
+            && self.last_netstatsd_reported == other.last_netstatsd_reported
+            && self.holoport_id == other.holoport_id
+            && self.registered_email == other.registered_email
+            && self.holo_network == other.holo_network
+            && self.channel == other.channel
+            && self.holoport_model == other.holoport_model
+            && self.ssh_status == other.ssh_status
+            && is_hashmap_equal(&self.hpos_app_list, &other.hpos_app_list)
+            && self.channel_version == other.channel_version
+            && self.hpos_version == other.hpos_version
+            && self.errors == other.errors
+    }
+}
+
+fn is_hashmap_equal(
+    first: &Option<HashMap<InstalledAppId, AppStatusFilter>>,
+    second: &Option<HashMap<InstalledAppId, AppStatusFilter>>,
+) -> bool {
+    match (first, second) {
+        (None, None) => true,
+        (Some(first_map), Some(second_map)) => true,
+        _ => false,
+    }
 }
 
 // Input type for /hosts/stats endpoint


### PR DESCRIPTION
## Context
Currently `list_available` endpoint returns data from production mongoDB's collection `host_statistics.holoport_status` that match the criteria:
- timestamp field is within last `cutoff` days
- returns latest (timestamp-wise) entry

The idea is to use additional data generated by Zerotier Central for obtaning deeper insight into holo network.

#### `netstatsd`

Each holoport running HPOS sends statistics reports with help of a systemd `netstatsd` service. Reports are sent every 60 minutes. Data is collected in `host_statistics.holoport_status` collection in a following format:
```json
{
  "_id": {
    "$oid": "62a31debe270e829c0209b03"
  },
  "holoNetwork": "alphaNet",
  "channel": "alpha",
  "holoportModel": "holoport",
  "sshStatus": true,
  "ztIp": "172.26.34.23",
  "wanIp": "217.236.230.36",
  "holoportId": "1fqumeojiht9cydqqh56durbxdu11qr3ayx8cvww3wnyn6nwob",
  "timestamp": {
    "$numberLong": "1654857195"
  },
  "hposAppList": {
    "uhCkk1V3LK08sFTVzcD-1Mum6mwGl6qbZjsuj9c6Y8AtPyekC6kTg:uhCAksyaK_Au776qFU6XFw08vv9Q3hnY91wXI3nLSBfT3mmmfHocd:###zero###": "Paused",
    "core-app:0_1_4::9bee3611-a9cf-4dfd-90f3-0ff451a66b98": "Running"
  },
  "channelVersion": "f9858f1589331aa0e748e178c881da0c97d3c622",
  "hposVersion": "f9858f1589331aa0e748e178c881da0c97d3c622"
}
```

####  `zerotierd`

In the same manner there's a `zerotierone.service` running on Holoports that maintains zerotier connection to Zerotier Central and between network members. Zerotier Central keeps data about those network members and exposes it at `https://api.zerotier.com/api/v1/network/{networkID}/member`. There's a service on holo's match server (called `services.zt-collector`) that copies data from Zerotier Central every 15 minutes and saves it in mongoDB's `host_statistics.latest_raw_snap` collection. Here is the schema:

```json
{
  "_id": {
    "$oid": "63b6d0fa9fa6110638d56ed2"
  },
  "index": {
    "$numberInt": "0"
  },
  "id": "93afae5963c547f1-28c090e76a",
  "type": "Member",
  "clock": {
    "$numberLong": "1672925385387"
  },
  "networkId": "93afae5963c547f1",
  "nodeId": "28c090e76a",
  "controllerId": "93afae5963",
  "hidden": false,
  "name": "5z1bbcrtjrcgzfm26xgwivrggdx1d02tqe88aj8pj9pva8l9hq",
  "online": false,
  "description": "fbeauregard@pyxis-tech.com",
  "config": {
    "activeBridge": false,
    "address": "28c090e76a",
    "authorized": true,
    "capabilities": [],
    "creationTime": {
      "$numberLong": "1647134567328"
    },
    "id": "28c090e76a",
    "identity": "28c090e76a:0:2f6c45b8b25a4f9fe14e4a34d7dec2244dda2e6de7a0eb816d5c0eebf478c80a5d6a614806fe0638f8473b24ed07cb5055528c2119c12fd06776b1d3f6657511",
    "ipAssignments": [
      "172.26.41.36"
    ],
    "lastAuthorizedTime": {
      "$numberLong": "1647134569144"
    },
    "lastDeauthorizedTime": {
      "$numberInt": "0"
    },
    "noAutoAssignIps": false,
    "nwid": "93afae5963c547f1",
    "objtype": "member",
    "remoteTraceLevel": {
      "$numberInt": "0"
    },
    "remoteTraceTarget": "NULL      ",
    "revision": {
      "$numberInt": "5"
    },
    "tags": [],
    "vMajor": {
      "$numberInt": "1"
    },
    "vMinor": {
      "$numberInt": "8"
    },
    "vRev": {
      "$numberInt": "4"
    },
    "vProto": {
      "$numberInt": "12"
    },
    "ssoExempt": false
  },
  "lastOnline": {
    "$numberLong": "1672861918235"
  },
  "physicalAddress": "70.83.67.254",
  "physicalLocation": null,
  "clientVersion": "1.8.4",
  "protocolVersion": {
    "$numberInt": "12"
  },
  "supportsRulesEngine": true
}
```

### Data analysis

Data stored in `host_statistics.holoport_status` represents a state of Holoport as seen by itself. Data in `host_statistics.latest_raw_snap` represents a view of a holoport from the perspective of network controller.

If our intention for `list_available` endpoint is to list only holoports reachible via holo network then one thing for sure - they have to have a Zerotier IP assigned and be authorized. So it looks as a good candidate for a primary key of a data set:
```
ZT.config.authorized == true
ZT.config.ipAssignments[0] -> not null
```

## Scope
In scope:
- [x] update `/list_available` endpoint of api
- [x] crate new `/cleanup` endpoint of api
- [x] unit tests
- [x] update readme

out of scope:
- [x] integration tests
